### PR TITLE
Fix spelling errors

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -837,7 +837,7 @@ recursive_protect ( ) {
 
 
 #############################
-# RESTORE_CLOBBERED FUNCION #
+# RESTORE_CLOBBERED FUNCTION #
 #############################
 restore_clobbered ( ) {
 
@@ -970,7 +970,7 @@ initialize ( ) {
     if test ! -d "$_aux_dir" ; then
 	_aux_dir=.
     else
-	$VERBOSE_ECHO "Detected auxillary directory: $_aux_dir"
+	$VERBOSE_ECHO "Detected auxiliary directory: $_aux_dir"
     fi
 
     ################################
@@ -1196,7 +1196,7 @@ if [ "x$HAVE_AUTORECONF" = "xyes" ] ; then
 	$ECHO "Warning: $AUTORECONF failed"
 
 	if test -f ltmain.sh ; then
-	    $ECHO "libtoolize being run by autoreconf is not creating ltmain.sh in the auxillary directory like it should"
+	    $ECHO "libtoolize being run by autoreconf is not creating ltmain.sh in the auxiliary directory like it should"
 	fi
 
 	$ECHO "Attempting to run the preparation steps individually"

--- a/doc/NEC2-bug.txt
+++ b/doc/NEC2-bug.txt
@@ -37,7 +37,7 @@ To fix the extended thin-wire kernel with patches in NEC-2:
        SUBROUTINE CMWW (J,I1,I2,CM,NR,CW,NW,ITRP)
        .
        .
-C     DECIDE WETHER EXT. T.W. APPROX. CAN BE USED
+C     DECIDE WHETHER EXT. T.W. APPROX. CAN BE USED
        IPR=ICON1(J)
        IF(IPR.GT.10000)GO TO 5      !<---NEW
        IF (IPR) 1,6,2

--- a/doc/xnec2c.html
+++ b/doc/xnec2c.html
@@ -8,7 +8,7 @@
 <meta name="date" content="2021-11-27T21:57:19-0700" >
 <meta name="copyright" content="GPL v2.0 or higher">
 <meta name="keywords" content="xnec2c GTK3 graphical nec2c NEC2 C simplex EM simulator">
-<meta name="description" content="Xnec2c is a high-performance multi-threaded electromagnetic simulation package to model antenna near- and far-field radiation patterns for Linux and UNIX operating systems.  The original FORTAN version of NEC2 was ported to C by Neoklis Kyriazis, 5B4AZ and released as nec2c.  Later, he wrote xnec2c a graphical interface for ease of use with many more features.">
+<meta name="description" content="Xnec2c is a high-performance multi-threaded electromagnetic simulation package to model antenna near- and far-field radiation patterns for Linux and UNIX operating systems.  The original FORTRAN version of NEC2 was ported to C by Neoklis Kyriazis, 5B4AZ and released as nec2c.  Later, he wrote xnec2c a graphical interface for ease of use with many more features.">
 <meta name="ROBOTS" content="INDEX, FOLLOW">
 <meta http-equiv="content-type" content="text/html; charset=utf-8">
 </head>
@@ -17,7 +17,7 @@
 <h1>Xnec2c: Graphical NEC2 Antenna Simulation</h1>
 Xnec2c is a high-performance multi-threaded electromagnetic simulation
 package to model antenna near- and far-field radiation patterns
-for Linux and UNIX operating systems.  The original FORTAN version of
+for Linux and UNIX operating systems.  The original FORTRAN version of
 NEC2 was ported to C by <a target="_blank" href="http://www.5b4az.org/">Neoklis Kyriazis, 5B4AZ</a> and released as nec2c.
 Later he wrote xnec2c, a graphical interface for ease of use with
 many more features:
@@ -1172,7 +1172,7 @@ Frequency Plots-&gt;View-&gt;Show S11
 xnec2c has always clamped to 10 so this option defaults enabled.  If you want to see the
 entire VSWR curve no matter how big VSWR is, then see Frequency Plots-&gt;View-&gt;Clamp VSWR to 10.
 </li>
-<li>Fixed deadlock while optimizing when inotify recieves a .nec change before xnec2c
+<li>Fixed deadlock while optimizing when inotify receives a .nec change before xnec2c
 is done writing the .nec.csv file.</li>
 </ul>
 </p>

--- a/examples/137MHz_turnstile_sloped.nec
+++ b/examples/137MHz_turnstile_sloped.nec
@@ -1,5 +1,5 @@
 CM --- NEC2 Input File created or edited by xnec2c 3.5 ---
-CM R.H. cicular polarized turnstile for 137 MHz
+CM R.H. circular polarized turnstile for 137 MHz
 CE --- End Comments ---
 GW     1    27   0.00000E+00  0.00000E+00  3.46945E-18  5.20000E-01  0.00000E+00  3.46945E-18  5.00000E-03
 GM     0     0   0.00000E+00  0.00000E+00  4.50000E+01  0.00000E+00  0.00000E+00  0.00000E+00  1.00000E+00

--- a/src/callback_func.c
+++ b/src/callback_func.c
@@ -80,7 +80,7 @@ New_Viewer_Angle(
     GtkSpinButton *wi_spb,
     projection_parameters_t *params )
 {
-  /* Recalculate projection paramenters */
+  /* Recalculate projection parameters */
   params->Wr = wr;
   params->Wi = wi;
 
@@ -582,7 +582,7 @@ Rdpattern_EH_Togglebutton_Toggled( gboolean flag )
     gtk_toggle_button_set_active( GTK_TOGGLE_BUTTON(Builder_Get_Object(
             rdpattern_window_builder, "rdpattern_gain_togglebutton")), FALSE );
 
-    /* Delegate near field calcuations to child
+    /* Delegate near field calculations to child
      * processes if forked and near field data valid */
     if( FORKED )
     {
@@ -613,7 +613,7 @@ Rdpattern_EH_Togglebutton_Toggled( gboolean flag )
       xnec2_widget_queue_draw( rdpattern_drawingarea );
     }
 
-    /* Disable near field calcuations
+    /* Disable near field calculations
      * by child processes if forked */
     Pass_EH_Flags();
   }

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -627,7 +627,7 @@ on_main_x_axis_clicked(
     GtkButton       *button,
     gpointer         user_data)
 {
-  /* Recalculate projection paramenters */
+  /* Recalculate projection parameters */
   New_Viewer_Angle( 0.0, 0.0, rotate_structure,
       incline_structure, &structure_proj_params );
   if( isFlagSet(DRAW_ENABLED) && isFlagSet(COMMON_PROJECTION) )
@@ -641,7 +641,7 @@ on_main_y_axis_clicked(
     GtkButton       *button,
     gpointer         user_data)
 {
-  /* Recalculate projection paramenters */
+  /* Recalculate projection parameters */
   New_Viewer_Angle( 90.0, 0.0, rotate_structure,
       incline_structure, &structure_proj_params );
   if( isFlagSet(DRAW_ENABLED) && isFlagSet(COMMON_PROJECTION) )
@@ -655,7 +655,7 @@ on_main_z_axis_clicked(
     GtkButton       *button,
     gpointer         user_data)
 {
-  /* Recalculate projection paramenters */
+  /* Recalculate projection parameters */
   New_Viewer_Angle( 0.0, 90.0, rotate_structure,
       incline_structure, &structure_proj_params );
   if( isFlagSet(DRAW_ENABLED) && isFlagSet(COMMON_PROJECTION) )
@@ -1353,7 +1353,7 @@ on_rdpattern_x_axis_clicked(
     GtkButton       *button,
     gpointer         user_data)
 {
-  /* Recalculate projection paramenters */
+  /* Recalculate projection parameters */
   New_Viewer_Angle( 0.0, 0.0, rotate_rdpattern,
       incline_rdpattern, &rdpattern_proj_params );
   if( isFlagSet(COMMON_PROJECTION) )
@@ -1367,7 +1367,7 @@ on_rdpattern_y_axis_clicked(
     GtkButton       *button,
     gpointer         user_data)
 {
-  /* Recalculate projection paramenters */
+  /* Recalculate projection parameters */
   New_Viewer_Angle( 90.0, 0.0, rotate_rdpattern,
       incline_rdpattern, &rdpattern_proj_params );
   if( isFlagSet(COMMON_PROJECTION) )
@@ -1381,7 +1381,7 @@ on_rdpattern_z_axis_clicked(
     GtkButton       *button,
     gpointer         user_data)
 {
-  /* Recalculate projection paramenters */
+  /* Recalculate projection parameters */
   New_Viewer_Angle( 0.0, 90.0, rotate_rdpattern,
       incline_rdpattern, &rdpattern_proj_params );
   if( isFlagSet(COMMON_PROJECTION) )

--- a/src/common.h
+++ b/src/common.h
@@ -110,7 +110,7 @@ typedef struct Segment
 /* Size of char arrays (strings) for error messages etc */
 #define MESG_SIZE   128
 
-/* Type of projection parameters stuct */
+/* Type of projection parameters struct */
 #define STRUCTURE_DRAWINGAREA   1
 #define RDPATTERN_DRAWINGAREA   2
 
@@ -651,7 +651,7 @@ typedef struct
 typedef struct
 {
   int
-    *isant, /* Num of segs on which an aplied field source is located */
+    *isant, /* Num of segs on which an applied field source is located */
     *ivqd,  /* Num of segs on which a current-slope discontinuity source is located */
     *iqds,  /* Same as above (?) */
     nsant,  /* Number of applied field voltage sources */
@@ -704,7 +704,7 @@ typedef struct
     width,   /*  Width of drawable */
     height;  /* Height of drawable */
 
-  char type; /* Type of projection parameters stuct */
+  char type; /* Type of projection parameters struct */
 
   gboolean reset;  /* Reset flag needed in some functions */
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -136,7 +136,7 @@ Draw_XYZ_Axes( cairo_t *cr, projection_parameters_t params )
 {
   static Segment_t seg[3];
 
-  /* Calcualte Screen co-ordinates of xyz axes */
+  /* Calculate Screen co-ordinates of xyz axes */
   Project_XYZ_Axes( cr, &params, seg );
 
   /* Draw xyz axes */

--- a/src/fork.c
+++ b/src/fork.c
@@ -55,7 +55,7 @@ Child_Input_File( void )
 
 /* Fork_Command()
  *
- * Identifies a command srting
+ * Identifies a command string
  */
   static int
 Fork_Command( const char *cdstr )
@@ -454,7 +454,7 @@ Child_Process( int num_child )
         Pass_Freq_Data();
         break;
 
-      case EHFIELD: /* Calcualte near field E/H data */
+      case EHFIELD: /* Calculate near field E/H data */
         {
           /* Get near field flags */
           char flag;

--- a/src/geom_edit.c
+++ b/src/geom_edit.c
@@ -1119,7 +1119,7 @@ Patch_Editor( int action )
   /* Hide/Show parts of window as needed */
   switch( ptype )
   {
-    case PATCH_ARBT: /* Arbitary shaped patch */
+    case PATCH_ARBT: /* Arbitrary shaped patch */
       gtk_widget_hide( Builder_Get_Object(patch_editor_builder, "patch_sc_frame") );
       gtk_widget_hide( Builder_Get_Object(patch_editor_builder, "patch_sm_frame") );
       gtk_window_resize( GTK_WINDOW(patch_editor), 10, 10 );
@@ -2067,7 +2067,7 @@ Scale_Editor( int action )
   /* Scale factor */
   static gdouble scale = 1.0;
 
-  /* Card (row) name, strings for convertions */
+  /* Card (row) name, strings for conversions */
   gchar name[3], sf[13], *str;
 
   static gboolean
@@ -2212,7 +2212,7 @@ Cylinder_Editor( int action )
     "cylinder_total_spinbutton"
   };
 
-  /* Card (row) name, strings for convertions */
+  /* Card (row) name, strings for conversions */
   gchar name[3];
 
   static gboolean
@@ -2340,7 +2340,7 @@ Transform_Editor( int action )
     "transform_mz_spinbutton"
   };
 
-  /* Card (row) name, strings for convertions */
+  /* Card (row) name, strings for conversions */
   gchar name[3];
 
   static gboolean
@@ -2465,7 +2465,7 @@ Gend_Editor( int action )
     "gend_img_radiobutton"
   };
 
-  /* Card (row) name, strings for convertions */
+  /* Card (row) name, strings for conversions */
   gchar name[3], *sv;
   static gchar si[6];
 
@@ -2602,7 +2602,7 @@ Check_Card_Name(
 
 /* Give_Up()
  *
- * Signals functon to abort if busy or no NEC2 editor window
+ * Signals function to abort if busy or no NEC2 editor window
  */
 
   gboolean

--- a/src/mathlib.c
+++ b/src/mathlib.c
@@ -571,7 +571,7 @@ void mathlib_benchmark(int slow)
 		 "* Only one Intel MKL library can be tested without restarting xnec2c, so select which one you wish"
 		 "to benchmark before proceeding or it will choose the first in the list and skip the rest.\n\n"
 		 "* Thread congestion will occur for multi-threaded libraries when using the -j N option if there are not enough "
-		 "CPUs available to accomodate the forked processes in combination with library threads.  Consider reducing the value of -j N for "
+		 "CPUs available to accommodate the forked processes in combination with library threads.  Consider reducing the value of -j N for "
 		 "benchmarking to find what library works best with a mix of forking and threading; you can use `top` to monitor your CPU usage"
 		 "and if it reaches 0% idle then you might consider reducing -j N.\n"
 		 "\n"

--- a/src/plot_freqdata.c
+++ b/src/plot_freqdata.c
@@ -390,12 +390,12 @@ static double Fit_to_Scale( double *max, double *min, int *nval )
   /* Scale subdivision 1 < subd < 10 */
   subdiv_val /= subdiv_order;
 
-  /* Find nearest prefered subdiv value */
+  /* Find nearest preferred subdiv value */
   for( idx = 1; idx <= 9; idx += 2 )
     if( scale_val[idx] >= subdiv_val )
       break;
 
-  /* Scale prefered subdiv value */
+  /* Scale preferred subdiv value */
   if( idx > 9 ) idx = 9;
   subdiv_val = scale_val[idx-1] * subdiv_order;
 
@@ -471,7 +471,7 @@ Fit_to_Scale2( double *max1, double *min1,
   // Scale subdivision 1 < subd < 10 
   subdiv_val1 /= subdiv_order1;
 
-  // Find nearest prefered subdiv value 
+  // Find nearest preferred subdiv value 
   idx1 = 1;
   while( (scale_val[idx1] > subdiv_val1) && (idx1 <= 4) )
     idx1++;
@@ -487,17 +487,17 @@ Fit_to_Scale2( double *max1, double *min1,
   // Scale subdivision 1 < subd < 10 
   subdiv_val2 /= subdiv_order2;
 
-  // Find nearest prefered subdiv value 
+  // Find nearest preferred subdiv value 
   idx2 = 1;
   while( (scale_val[idx2] > subdiv_val2) && (idx2 <= 4) )
     idx2++;
 
-  // Search for a compromize in scale stretching 
+  // Search for a compromise in scale stretching 
   range1 = *max1 - *min1;
   range2 = *max2 - *min2;
   min_stretch = 10.0;
 
-  // Scale prefered subdiv values 
+  // Scale preferred subdiv values 
   subdiv_val1 = scale_val[idx1] * subdiv_order1;
   subdiv_val2 = scale_val[idx2] * subdiv_order2;
 
@@ -522,7 +522,7 @@ Fit_to_Scale2( double *max1, double *min1,
     {
       double stretch;
 
-      /* Scale prefered subdiv values */
+      /* Scale preferred subdiv values */
       subdiv_val1 = scale_val[idx1-i1] * subdiv_order1;
       subdiv_val2 = scale_val[idx2-i2] * subdiv_order2;
 
@@ -1758,7 +1758,7 @@ _Set_Frequency_On_Click( GdkEvent *e)
   /* Width of plot bounding rectangle */
   w = fr_plot->plot_rect.width;
 
-  /* 'x' posn of click refered to plot bounding rectangle's 'x' */
+  /* 'x' posn of click referred to plot bounding rectangle's 'x' */
   x = button_event->x - fr_plot->plot_rect.x;
   if( x < 0.0 ) x = 0.0;
   else if( x > w ) x = w;

--- a/src/shared.c
+++ b/src/shared.c
@@ -81,7 +81,7 @@ GtkTreeView
   *geom_treeview = NULL,
   *cmnd_treeview = NULL;
 
-/* Main, frequency plots and radation pattern windows */
+/* Main, frequency plots and radiation pattern windows */
 GtkWidget
   *main_window      = NULL,
   *freqplots_window = NULL,

--- a/src/shared.h
+++ b/src/shared.h
@@ -116,7 +116,7 @@ extern GtkTreeView
   *geom_treeview,
   *cmnd_treeview ;
 
-/* Main, frequency plots and radation pattern windows */
+/* Main, frequency plots and radiation pattern windows */
 extern GtkWidget
   *main_window,
   *freqplots_window,

--- a/src/utils.c
+++ b/src/utils.c
@@ -379,7 +379,7 @@ SaveFlag( unsigned long long int *flag, unsigned long long int mask )
 /* Strlcpy()
  *
  * Copies n-1 chars from src string into dest string. Unlike other
- * such library fuctions, this makes sure that the dest string is
+ * such library functions, this makes sure that the dest string is
  * null terminated by copying only n-1 chars to leave room for the
  * terminating char. n would normally be the sizeof(dest) string but
  * copying will not go beyond the terminating null of src string
@@ -412,7 +412,7 @@ Strlcpy( char *dest, const char *src, size_t n )
 /* Strlcat()
  *
  * Concatenates at most n-1 chars from src string into dest string.
- * Unlike other such library fuctions, this makes sure that the dest
+ * Unlike other such library functions, this makes sure that the dest
  * string is null terminated by copying only n-1 chars to leave room
  * for the terminating char. n would normally be the sizeof(dest)
  * string but copying will not go beyond the terminating null of src


### PR DESCRIPTION
This PR fixes some trivial spelling errors found semi-automatically using codespell.

Fixed with:
codespell --ignore-words-list ans,conect,co-ordinate,co-ordinates,cppp,ist,nd,sav,tha,tht --interactive 2 --write-changes