### PR TITLE
Fix spelling

### DIFF
--- a/doc/xnec2c.1
+++ b/doc/xnec2c.1
@@ -29,7 +29,7 @@ a translation to C of the FORTRAN application NEC2
 [\-d: enable debug output (-dd includes backtraces)]
 .SH "SEE ALSO"
 Full documentation is available at the official website for xnec2c
-.URL "https://www.xnec2c.org/" "Offical xnec2c Website" .
+.URL "https://www.xnec2c.org/" "Official xnec2c Website" .
 In addition, the full documentation for
 .B xnec2c
 is maintained as an html document.  If the

--- a/doc/xnec2c.html
+++ b/doc/xnec2c.html
@@ -1292,7 +1292,7 @@ that do not align nicely to whole numbers or common fractions of numbers
 The new option "View-&gt;Round X Axis Frequency Values" will align the X Axis
 labels to normalized values as originally designed in releases prior
 to v4.1.5.  When this option is off, it will show one more frequency
-signifigant figure displayed on the X Axis and scale the plot to use
+significant figure displayed on the X Axis and scale the plot to use
 the entire plot space.
 </p>
 <p><b>Version 4.4.4:</b>

--- a/resources/xnec2c.glade
+++ b/resources/xnec2c.glade
@@ -18,7 +18,7 @@ xnec2c can display frequency-dependent data (gain, input impedance, vswr etc) in
 
 xnec2c has a built-in NEC2 input file editor that makes it easier to create or edit antenna description files and specify NEC2 commands.
 
-PLEASE read the documantation in the doc/ sub-directory as xnec2c is not fully compatible with NEC2 input files and it works in different ways!</property>
+PLEASE read the documentation in the doc/ sub-directory as xnec2c is not fully compatible with NEC2 input files and it works in different ways!</property>
     <property name="website">https://www.xnec2c.org/</property>
     <property name="authors">Neoklis Kyriazis
 	  Ham Radio Call: 5B4AZ
@@ -7465,7 +7465,7 @@ Save NEC2 Editor data first?
                 <property name="spacing">2</property>
                 <child>
                   <object class="GtkRadioButton" id="patch_arbitrary_radiobutton">
-                    <property name="label" translatable="yes">Arbitary</property>
+                    <property name="label" translatable="yes">Arbitrary</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>

--- a/src/common.h
+++ b/src/common.h
@@ -249,7 +249,7 @@ typedef struct
   char input_file[FILENAME_LEN];
 
   /* If set true, then use GTK loops for the frequency loop iteration
-   * instead of spawing a pthread */
+   * instead of spawning a pthread */
   int disable_pthread_freqloop;
 
   /* Main (structure) window position and size */

--- a/src/measurements.c
+++ b/src/measurements.c
@@ -166,7 +166,7 @@ int meas_name_idx(char *name, int len)
 
 	if (i == MEAS_COUNT)
 	{
-		BUG("meas_name_idx: Invald name with length=%d: %s\n", len, name);
+		BUG("meas_name_idx: Invalid name with length=%d: %s\n", len, name);
 		print_backtrace(NULL);
 	}
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -237,7 +237,7 @@ Load_Line( char *buff, FILE *pfile )
 
 /* xnec2c uses mem_realloc() very often to resize buffers in the code.
  * There are cases where uninitialized memory buffers can lead to incorrect behavior
- * but unfortunatly the libc realloc() call doesn't initialize the reallocated memory.
+ * but unfortunately the libc realloc() call doesn't initialize the reallocated memory.
  * 
  * Since there is not a portable way to discover the amount of memory allocated by the
  * previous realloc/malloc() call we cannot call memset() on the extended portion.

--- a/xnec2c.spec
+++ b/xnec2c.spec
@@ -187,7 +187,7 @@ update-desktop-database &> /dev/null || :
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_29_Mass_Rebuild
 
 * Thu May 31 2018 Richard Shaw <hobbes1069@gmail.com> - 3.9-0.1
-- Update to 3.9 Beta with GTK3 suppoert.
+- Update to 3.9 Beta with GTK3 support.
 
 * Fri Feb 09 2018 Fedora Release Engineering <releng@fedoraproject.org> - 3.5.1-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_28_Mass_Rebuild


### PR DESCRIPTION
Fixed with:
codespell --ignore-words-list ans,conect,co-ordinate,co-ordinates,cppp,ist,nd,sav,tha,tht --skip=ABOUT-NLS,po --summary --write-changes