### PR TITLE
Fix cross compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,7 +76,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
        [AC_MSG_RESULT([no])])
 
 AC_MSG_CHECKING([whether dlopen supports LMID])
-AC_RUN_IFELSE([AC_LANG_PROGRAM([
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
 			#define _GNU_SOURCE
 			#include <link.h>
 			#include <dlfcn.h>


### PR DESCRIPTION
102e3cef58eb796dd6b3bb099ed0103bcc3d9c75 introduced a check for LMID in
libc to fix compilation on musl, but it used AC_RUN_IFELSE even though
only a compile check is needed. AC_RUN_IFELSE is not available with
cross compilation.