### PR TITLE
Fix type errors with glib 2.73

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -1487,8 +1487,8 @@ void Strlcat(char *dest, const char *src, size_t n);
 double Strtod(char *nptr, char **endptr);
 void Get_Dirname(char *fpath, char *dirname, int *fname_idx);
 void xnec2_widget_queue_draw(GtkWidget *w);
-void g_idle_add_once(GSourceFunc function, gpointer data);
-void g_idle_add_once_sync(GSourceFunc function, gpointer data);
+guint g_idle_add_once(GSourceOnceFunc function, gpointer data);
+void g_idle_add_once_sync(GSourceOnceFunc function, gpointer data);
 void print_backtrace(char *msg);
 
 /* xnec2c.c */

--- a/src/utils.c
+++ b/src/utils.c
@@ -681,7 +681,7 @@ int _callback_g_idle_add_once(g_idle_add_data_t *cbdata)
 	return FALSE;
 }
 
-void _g_idle_add_once(GSourceFunc function, gpointer data, int lock)
+void _g_idle_add_once(GSourceOnceFunc function, gpointer data, int lock)
 {
 	g_idle_add_data_t *cbdata = NULL;
 	mem_alloc((void**)&cbdata, sizeof(g_idle_add_data_t), __LOCATION__);
@@ -717,13 +717,13 @@ void _g_idle_add_once(GSourceFunc function, gpointer data, int lock)
 }
 
 // Call from any thread to queue a function to run once, do not wait for it to finish.
-void g_idle_add_once(GSourceFunc function, gpointer data)
+guint g_idle_add_once(GSourceOnceFunc function, gpointer data)
 {
 	_g_idle_add_once(function, data, 0); // async
 }
 
 // Call from another thread to queue a function to run once, and wait for it to finish.
-void g_idle_add_once_sync(GSourceFunc function, gpointer data)
+void g_idle_add_once_sync(GSourceOnceFunc function, gpointer data)
 {
 	_g_idle_add_once(function, data, 1); // sync
 }
@@ -739,7 +739,7 @@ void xnec2_widget_queue_draw(GtkWidget *w)
 		pr_debug("Optimizer loop incomplete, skipping radiation pattern redraw.\n");
 	}
 	else
-		g_idle_add_once((GSourceFunc)gtk_widget_queue_draw, w);
+		g_idle_add_once((GSourceOnceFunc)gtk_widget_queue_draw, w);
 
 }
 /*------------------------------------------------------------------*/

--- a/src/xnec2c.c
+++ b/src/xnec2c.c
@@ -852,7 +852,7 @@ gboolean Frequency_Loop( gpointer udata )
 	if( isFlagSet(PLOT_ENABLED) )
 	{
 	  /* Display current frequency in plots entry */
-	  g_idle_add_once((GSourceFunc)update_freqplots_fmhz_entry, NULL);
+	  g_idle_add_once((GSourceOnceFunc)update_freqplots_fmhz_entry, NULL);
 
 	  if( isFlagClear(OPTIMIZER_OUTPUT) || freqplots_click_pending())
 	  {
@@ -861,11 +861,11 @@ gboolean Frequency_Loop( gpointer udata )
 	}
 
 	/* Set main window frequency spinbutton */
-	g_idle_add_once((GSourceFunc)update_freq_mhz_spin_button_value, mainwin_frequency);
+	g_idle_add_once((GSourceOnceFunc)update_freq_mhz_spin_button_value, mainwin_frequency);
 
 	/* Set Radiation pattern window frequency spinbutton */
 	if( isFlagSet(DRAW_ENABLED) )
-		  g_idle_add_once((GSourceFunc)update_freq_mhz_spin_button_value, rdpattern_frequency);
+		  g_idle_add_once((GSourceOnceFunc)update_freq_mhz_spin_button_value, rdpattern_frequency);
 
 	xnec2_widget_queue_draw( structure_drawingarea );
   }
@@ -901,17 +901,17 @@ gboolean Frequency_Loop( gpointer udata )
 
       /* Set main window frequency spinbutton.
 	   * This will trigger New_Frequency() via Redo_Currents(). */
-      g_idle_add_once_sync((GSourceFunc)update_freq_mhz_spin_button_value, mainwin_frequency);
+      g_idle_add_once_sync((GSourceOnceFunc)update_freq_mhz_spin_button_value, mainwin_frequency);
 
       /* Set Radiation pattern window frequency spinbutton.
 	   * This will trigger New_Frequency() via Redo_Radiation_Pattern,. */
       if( isFlagSet(DRAW_ENABLED) )
-        g_idle_add_once_sync((GSourceFunc)update_fmhz_save_spin_button_value, rdpattern_frequency);
+        g_idle_add_once_sync((GSourceOnceFunc)update_fmhz_save_spin_button_value, rdpattern_frequency);
 
       if( isFlagSet(PLOT_ENABLED) )
       {
         SetFlag( PLOT_FREQ_LINE );
-        g_idle_add_once_sync((GSourceFunc)update_freqplots_fmhz_entry, NULL);
+        g_idle_add_once_sync((GSourceOnceFunc)update_freqplots_fmhz_entry, NULL);
       }
     }
 
@@ -925,7 +925,7 @@ gboolean Frequency_Loop( gpointer udata )
      * the optimizer if SIGHUP received */
     if( isFlagSet(OPTIMIZER_OUTPUT) )
     {
-      g_idle_add_once_sync((GSourceFunc)Write_Optimizer_Data, NULL);
+      g_idle_add_once_sync((GSourceOnceFunc)Write_Optimizer_Data, NULL);
     }
   } // if( !retval && !num_busy_procs )
 
@@ -972,14 +972,14 @@ void *Frequency_Loop_Thread(void *p)
 	   Re-draw drawing areas at end of loop 
 	 */
 	if (isFlagSet(PLOT_ENABLED))
-		g_idle_add_once_sync((GSourceFunc) gtk_widget_queue_draw, freqplots_drawingarea);
+		g_idle_add_once_sync((GSourceOnceFunc) gtk_widget_queue_draw, freqplots_drawingarea);
 
 	if (isFlagSet(DRAW_ENABLED))
 	{
-		g_idle_add_once_sync((GSourceFunc) update_freq_mhz_spin_button_value, rdpattern_frequency);
-		g_idle_add_once_sync((GSourceFunc)update_freq_mhz_spin_button_value, mainwin_frequency);
+		g_idle_add_once_sync((GSourceOnceFunc) update_freq_mhz_spin_button_value, rdpattern_frequency);
+		g_idle_add_once_sync((GSourceOnceFunc)update_freq_mhz_spin_button_value, mainwin_frequency);
 		g_idle_add_once_sync(Redo_Currents, NULL);
-		g_idle_add_once_sync((GSourceFunc) gtk_widget_queue_draw, rdpattern_drawingarea);
+		g_idle_add_once_sync((GSourceOnceFunc) gtk_widget_queue_draw, rdpattern_drawingarea);
 	}
 
 	return NULL;


### PR DESCRIPTION
On Debian unstable, xnec2c fails to compile:

```
common.h:1453:6: error: conflicting types for 'g_idle_add_once'; have 'void(gboolean (*)(void *), void *)' {aka 'void(int (*)(void *), void *)'}
 1453 | void g_idle_add_once(GSourceFunc function, gpointer data);
      |      ^~~~~~~~~~~~~~~
In file included from /usr/include/glib-2.0/glib/giochannel.h:35,
                 from /usr/include/glib-2.0/glib.h:56,
                 from /usr/include/gtk-3.0/gdk/gdkconfig.h:13,
                 from /usr/include/gtk-3.0/gdk/gdk.h:30,
                 from /usr/include/gtk-3.0/gtk/gtk.h:30,
                 from common.h:35:
/usr/include/glib-2.0/glib/gmain.h:822:10: note: previous declaration of 'g_idle_add_once' with type 'guint(void (*)(void *), void *)' {aka 'unsigned int(void (*)(void *), void *)'}
  822 | guint    g_idle_add_once            (GSourceOnceFunc function,
      |          ^~~~~~~~~~~~~~~
```

The attached patch fixes the issue here. The net change is:

```
-void g_idle_add_once(GSourceFunc function, gpointer data);
+guint g_idle_add_once(GSourceOnceFunc function, gpointer data);

-void g_idle_add_once_sync(GSourceFunc function, gpointer data);
+void g_idle_add_once_sync(GSourceOnceFunc function, gpointer data);
```

Note that I did not verify if that change is backwards compatible with older library versions.