### PR TITLE
xnec2c --help output should go to stdout, not stderr

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -40,7 +40,7 @@ void _print_backtrace(char **strings);
   void
 usage(void)
 {
-  fprintf(stderr, "Usage: xnec2c [options] [<input-file-name>]\n"
+  fprintf(stdout, "Usage: xnec2c [options] [<input-file-name>]\n"
 		"  -i|--input <input-file-name>\n"
 		"  -j|--jobs  <number of processors in SMP machine> (-j0 disables forking)\n"
 		"  -b|--batch:        enable batch mode, exit after the frequency loop runs\n"


### PR DESCRIPTION
The output of `xnec2c --help` should be written to `stdout` just like `xnec2c --version` already writes to `stdout`. Both the `--help` and the `--version` branch exit the program with `exit(0)` so there is no reason to assume either output is somewhat error related.

Note that fixing this does not mean we can enable the `std-options` Automake flag for `make installcheck` time checking that all installed programs support `--help` and `--version`.

For some reason (might be GTK3 limitations, limitations by the default way of using GTK3, or limitations by xnec2c), `xnec2c` opens the display before handling `--help` or `--version`.

So the check for `--help` and `--version` would fail in headless build environments until opening the display has been moved after parsing and handling of the CLI arguments.