### PR TITLE
Fix double free when editing geometry

### DIFF
--- a/src/geom_edit.c
+++ b/src/geom_edit.c
@@ -303,7 +303,6 @@ Get_Wire_Conductivity( int tag, double *s, GtkListStore *store )
       {
         break;
       }
-      else g_free( str );
     }
     else g_free( str );
 


### PR DESCRIPTION
I wasn't able to edit the geometry. Whenever I double clicked on a row, it would crash.

Using `-fsanitize=address` shows the cause:

```
=================================================================
==167414==ERROR: AddressSanitizer: attempting double-free on 0x5020001d6c30 in thread T0:
    #0 0x7f2268708518 in free.part.0 (/lib64/libasan.so.8+0xc1518) (BuildId: 89c230c891879ee538159d2e56f56784c84db409)
    #1 0x7f2268531ec4 in g_free (/lib64/libglib-2.0.so.0+0x40ec4) (BuildId: 22d79f4920ad3a59cb8611276e6b6b95da3b654b)
    #2 0x446806 in Get_Wire_Conductivity /home/dev/repo/hw/radio/antenna/xnec2c/src/geom_edit.c:306
    #3 0x447a5c in Wire_Editor /home/dev/repo/hw/radio/antenna/xnec2c/src/geom_edit.c:542
    #4 0x426184 in Card_Clicked /home/dev/repo/hw/radio/antenna/xnec2c/src/callback_func.c:422
    #5 0x41fa2f in on_gw_clicked /home/dev/repo/hw/radio/antenna/xnec2c/src/callbacks.c:2726
    #6 0x7f226784c55b in signal_emit_valist_unlocked (/lib64/libgobject-2.0.so.0+0x2855b) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #7 0x7f226784c947 in g_signal_emit_by_name (/lib64/libgobject-2.0.so.0+0x28947) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #8 0x425faf in Open_Editor /home/dev/repo/hw/radio/antenna/xnec2c/src/callback_func.c:387
    #9 0x41f1a1 in on_nec2_geom_treeview_button_press_event /home/dev/repo/hw/radio/antenna/xnec2c/src/callbacks.c:2460
    #10 0x7f2267dc0633 in _gtk_marshal_BOOLEAN__OBJECT.part.0 (/lib64/libgtk-3.so.0+0x8d633) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #11 0x7f226782b7d9 in g_closure_invoke (/lib64/libgobject-2.0.so.0+0x77d9) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #12 0x7f226785b8f2 in signal_emit_unlocked_R.isra.0 (/lib64/libgobject-2.0.so.0+0x378f2) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #13 0x7f226784bbf3 in signal_emit_valist_unlocked (/lib64/libgobject-2.0.so.0+0x27bf3) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #14 0x7f226784c670 in g_signal_emit_valist (/lib64/libgobject-2.0.so.0+0x28670) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #15 0x7f226784c732 in g_signal_emit (/lib64/libgobject-2.0.so.0+0x28732) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #16 0x7f2268092e3b in gtk_widget_event_internal.part.0.lto_priv.0 (/lib64/libgtk-3.so.0+0x35fe3b) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #17 0x7f2267f27327 in propagate_event.lto_priv.0 (/lib64/libgtk-3.so.0+0x1f4327) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #18 0x7f2267f280a9 in gtk_main_do_event (/lib64/libgtk-3.so.0+0x1f50a9) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #19 0x7f2267c67806 in _gdk_event_emit (/lib64/libgdk-3.so.0+0x2d806) (BuildId: a21da90af9870f33f22d2064f21adbaadc59a001)
    #20 0x7f2267ca12ad in gdk_event_source_dispatch (/lib64/libgdk-3.so.0+0x672ad) (BuildId: a21da90af9870f33f22d2064f21adbaadc59a001)
    #21 0x7f226853128b in g_main_context_dispatch_unlocked.lto_priv.0 (/lib64/libglib-2.0.so.0+0x4028b) (BuildId: 22d79f4920ad3a59cb8611276e6b6b95da3b654b)
    #22 0x7f22685918b7 in g_main_context_iterate_unlocked.isra.0 (/lib64/libglib-2.0.so.0+0xa08b7) (BuildId: 22d79f4920ad3a59cb8611276e6b6b95da3b654b)
    #23 0x7f2268537376 in g_main_loop_run (/lib64/libglib-2.0.so.0+0x46376) (BuildId: 22d79f4920ad3a59cb8611276e6b6b95da3b654b)
    #24 0x7f2267f22b34 in gtk_main (/lib64/libgtk-3.so.0+0x1efb34) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #25 0x40522e in main /home/dev/repo/hw/radio/antenna/xnec2c/src/main.c:442
    #26 0x7f226754c247 in __libc_start_call_main (/lib64/libc.so.6+0x3247) (BuildId: b840d32d15506ed2f29610c7f512d9084f2d7d69)
    #27 0x7f226754c30a in __libc_start_main_alias_1 (/lib64/libc.so.6+0x330a) (BuildId: b840d32d15506ed2f29610c7f512d9084f2d7d69)
    #28 0x402124 in _start (/host/var/home/dev/repo/hw/radio/antenna/xnec2c/src/xnec2c+0x402124) (BuildId: 50ce25e5afbd0987ac9be9e03f1720c652c5af2d)

0x5020001d6c30 is located 0 bytes inside of 3-byte region [0x5020001d6c30,0x5020001d6c33)
freed by thread T0 here:
    #0 0x7f2268708518 in free.part.0 (/lib64/libasan.so.8+0xc1518) (BuildId: 89c230c891879ee538159d2e56f56784c84db409)
    #1 0x7f2268531ec4 in g_free (/lib64/libglib-2.0.so.0+0x40ec4) (BuildId: 22d79f4920ad3a59cb8611276e6b6b95da3b654b)
    #2 0x44673b in Get_Wire_Conductivity /home/dev/repo/hw/radio/antenna/xnec2c/src/geom_edit.c:298
    #3 0x447a5c in Wire_Editor /home/dev/repo/hw/radio/antenna/xnec2c/src/geom_edit.c:542
    #4 0x426184 in Card_Clicked /home/dev/repo/hw/radio/antenna/xnec2c/src/callback_func.c:422
    #5 0x41fa2f in on_gw_clicked /home/dev/repo/hw/radio/antenna/xnec2c/src/callbacks.c:2726
    #6 0x7f226784c55b in signal_emit_valist_unlocked (/lib64/libgobject-2.0.so.0+0x2855b) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #7 0x7f226784c947 in g_signal_emit_by_name (/lib64/libgobject-2.0.so.0+0x28947) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #8 0x425faf in Open_Editor /home/dev/repo/hw/radio/antenna/xnec2c/src/callback_func.c:387
    #9 0x41f1a1 in on_nec2_geom_treeview_button_press_event /home/dev/repo/hw/radio/antenna/xnec2c/src/callbacks.c:2460
    #10 0x7f2267dc0633 in _gtk_marshal_BOOLEAN__OBJECT.part.0 (/lib64/libgtk-3.so.0+0x8d633) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #11 0x7f226782b7d9 in g_closure_invoke (/lib64/libgobject-2.0.so.0+0x77d9) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #12 0x7f226785b8f2 in signal_emit_unlocked_R.isra.0 (/lib64/libgobject-2.0.so.0+0x378f2) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #13 0x7f226784bbf3 in signal_emit_valist_unlocked (/lib64/libgobject-2.0.so.0+0x27bf3) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #14 0x7f226784c670 in g_signal_emit_valist (/lib64/libgobject-2.0.so.0+0x28670) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #15 0x7f226784c732 in g_signal_emit (/lib64/libgobject-2.0.so.0+0x28732) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #16 0x7f2268092e3b in gtk_widget_event_internal.part.0.lto_priv.0 (/lib64/libgtk-3.so.0+0x35fe3b) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #17 0x7f2267f27327 in propagate_event.lto_priv.0 (/lib64/libgtk-3.so.0+0x1f4327) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #18 0x7f2267f280a9 in gtk_main_do_event (/lib64/libgtk-3.so.0+0x1f50a9) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #19 0x7f2267c67806 in _gdk_event_emit (/lib64/libgdk-3.so.0+0x2d806) (BuildId: a21da90af9870f33f22d2064f21adbaadc59a001)
    #20 0x7f2267ca12ad in gdk_event_source_dispatch (/lib64/libgdk-3.so.0+0x672ad) (BuildId: a21da90af9870f33f22d2064f21adbaadc59a001)
    #21 0x7f226853128b in g_main_context_dispatch_unlocked.lto_priv.0 (/lib64/libglib-2.0.so.0+0x4028b) (BuildId: 22d79f4920ad3a59cb8611276e6b6b95da3b654b)
    #22 0x7f22685918b7 in g_main_context_iterate_unlocked.isra.0 (/lib64/libglib-2.0.so.0+0xa08b7) (BuildId: 22d79f4920ad3a59cb8611276e6b6b95da3b654b)
    #23 0x7f2268537376 in g_main_loop_run (/lib64/libglib-2.0.so.0+0x46376) (BuildId: 22d79f4920ad3a59cb8611276e6b6b95da3b654b)
    #24 0x7f2267f22b34 in gtk_main (/lib64/libgtk-3.so.0+0x1efb34) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #25 0x40522e in main /home/dev/repo/hw/radio/antenna/xnec2c/src/main.c:442
    #26 0x7f226754c247 in __libc_start_call_main (/lib64/libc.so.6+0x3247) (BuildId: b840d32d15506ed2f29610c7f512d9084f2d7d69)
    #27 0x7f226754c30a in __libc_start_main_alias_1 (/lib64/libc.so.6+0x330a) (BuildId: b840d32d15506ed2f29610c7f512d9084f2d7d69)
    #28 0x402124 in _start (/host/var/home/dev/repo/hw/radio/antenna/xnec2c/src/xnec2c+0x402124) (BuildId: 50ce25e5afbd0987ac9be9e03f1720c652c5af2d)

previously allocated by thread T0 here:
    #0 0x7f2268709877 in malloc (/lib64/libasan.so.8+0xc2877) (BuildId: 89c230c891879ee538159d2e56f56784c84db409)
    #1 0x7f2268537cb9 in g_malloc (/lib64/libglib-2.0.so.0+0x46cb9) (BuildId: 22d79f4920ad3a59cb8611276e6b6b95da3b654b)
    #2 0x7f2268551658 in g_strdup (/lib64/libglib-2.0.so.0+0x60658) (BuildId: 22d79f4920ad3a59cb8611276e6b6b95da3b654b)
    #3 0x7f2267851c3b in value_lcopy_string (/lib64/libgobject-2.0.so.0+0x2dc3b) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #4 0x7f226803fee9 in gtk_tree_model_get_valist (/lib64/libgtk-3.so.0+0x30cee9) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #5 0x7f226804021e in gtk_tree_model_get (/lib64/libgtk-3.so.0+0x30d21e) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #6 0x4466f0 in Get_Wire_Conductivity /home/dev/repo/hw/radio/antenna/xnec2c/src/geom_edit.c:293
    #7 0x447a5c in Wire_Editor /home/dev/repo/hw/radio/antenna/xnec2c/src/geom_edit.c:542
    #8 0x426184 in Card_Clicked /home/dev/repo/hw/radio/antenna/xnec2c/src/callback_func.c:422
    #9 0x41fa2f in on_gw_clicked /home/dev/repo/hw/radio/antenna/xnec2c/src/callbacks.c:2726
    #10 0x7f226784c55b in signal_emit_valist_unlocked (/lib64/libgobject-2.0.so.0+0x2855b) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #11 0x7f226784c947 in g_signal_emit_by_name (/lib64/libgobject-2.0.so.0+0x28947) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #12 0x425faf in Open_Editor /home/dev/repo/hw/radio/antenna/xnec2c/src/callback_func.c:387
    #13 0x41f1a1 in on_nec2_geom_treeview_button_press_event /home/dev/repo/hw/radio/antenna/xnec2c/src/callbacks.c:2460
    #14 0x7f2267dc0633 in _gtk_marshal_BOOLEAN__OBJECT.part.0 (/lib64/libgtk-3.so.0+0x8d633) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #15 0x7f226782b7d9 in g_closure_invoke (/lib64/libgobject-2.0.so.0+0x77d9) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #16 0x7f226785b8f2 in signal_emit_unlocked_R.isra.0 (/lib64/libgobject-2.0.so.0+0x378f2) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #17 0x7f226784bbf3 in signal_emit_valist_unlocked (/lib64/libgobject-2.0.so.0+0x27bf3) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #18 0x7f226784c670 in g_signal_emit_valist (/lib64/libgobject-2.0.so.0+0x28670) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #19 0x7f226784c732 in g_signal_emit (/lib64/libgobject-2.0.so.0+0x28732) (BuildId: a96e44f4777ac06d8792f12f48c868c2e2a55f58)
    #20 0x7f2268092e3b in gtk_widget_event_internal.part.0.lto_priv.0 (/lib64/libgtk-3.so.0+0x35fe3b) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #21 0x7f2267f27327 in propagate_event.lto_priv.0 (/lib64/libgtk-3.so.0+0x1f4327) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #22 0x7f2267f280a9 in gtk_main_do_event (/lib64/libgtk-3.so.0+0x1f50a9) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #23 0x7f2267c67806 in _gdk_event_emit (/lib64/libgdk-3.so.0+0x2d806) (BuildId: a21da90af9870f33f22d2064f21adbaadc59a001)
    #24 0x7f2267ca12ad in gdk_event_source_dispatch (/lib64/libgdk-3.so.0+0x672ad) (BuildId: a21da90af9870f33f22d2064f21adbaadc59a001)
    #25 0x7f226853128b in g_main_context_dispatch_unlocked.lto_priv.0 (/lib64/libglib-2.0.so.0+0x4028b) (BuildId: 22d79f4920ad3a59cb8611276e6b6b95da3b654b)
    #26 0x7f22685918b7 in g_main_context_iterate_unlocked.isra.0 (/lib64/libglib-2.0.so.0+0xa08b7) (BuildId: 22d79f4920ad3a59cb8611276e6b6b95da3b654b)
    #27 0x7f2268537376 in g_main_loop_run (/lib64/libglib-2.0.so.0+0x46376) (BuildId: 22d79f4920ad3a59cb8611276e6b6b95da3b654b)
    #28 0x7f2267f22b34 in gtk_main (/lib64/libgtk-3.so.0+0x1efb34) (BuildId: f5e535e89c52858d4973757579aac851ceeb58b1)
    #29 0x40522e in main /home/dev/repo/hw/radio/antenna/xnec2c/src/main.c:442

SUMMARY: AddressSanitizer: double-free (/lib64/libasan.so.8+0xc1518) (BuildId: 89c230c891879ee538159d2e56f56784c84db409) in free.part.0
==167414==ABORTING
```