### PR TITLE
lang: sync Z0/Z₀ and Tx Line Zo string changes in all 47 catalogs

### DIFF
--- a/po/af.po
+++ b/po/af.po
@@ -1887,8 +1887,8 @@ msgid "Port"
 msgstr "Poort"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx Lyn Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx Lyn Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3362,8 +3362,8 @@ msgstr "golflengtes → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/ar.po
+++ b/po/ar.po
@@ -1873,8 +1873,8 @@ msgid "Port"
 msgstr "المنفذ"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo خط النقل"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> خط النقل"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3332,8 +3332,8 @@ msgstr "أطوال موجية ← مولّد"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/bg.po
+++ b/po/bg.po
@@ -1892,8 +1892,8 @@ msgid "Port"
 msgstr "Порт"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx линия Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx линия Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3369,8 +3369,8 @@ msgstr "дължини на вълната → ген"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/bn.po
+++ b/po/bn.po
@@ -1878,8 +1878,8 @@ msgid "Port"
 msgstr "পোর্ট"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx লাইন Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx লাইন Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3340,8 +3340,8 @@ msgstr "তরঙ্গদৈর্ঘ্য → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/bs.po
+++ b/po/bs.po
@@ -1883,8 +1883,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx linija Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx linija Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3354,8 +3354,8 @@ msgstr "talasne dužine → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/cs.po
+++ b/po/cs.po
@@ -1883,8 +1883,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx vedení Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx vedení Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3348,8 +3348,8 @@ msgstr "vlnové délky → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/da.po
+++ b/po/da.po
@@ -1884,8 +1884,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx-linje Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx-linje Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3354,8 +3354,8 @@ msgstr "bølgelængder → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/de.po
+++ b/po/de.po
@@ -1894,8 +1894,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx-Leitung Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx-Leitung Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3369,8 +3369,8 @@ msgstr "Wellenlängen → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/el.po
+++ b/po/el.po
@@ -1900,8 +1900,8 @@ msgid "Port"
 msgstr "Θύρα"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo Γραμμής Tx"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> Γραμμής Tx"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3386,8 +3386,8 @@ msgstr "μήκη κύματος → γεν."
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/es.po
+++ b/po/es.po
@@ -1897,8 +1897,8 @@ msgid "Port"
 msgstr "Puerto"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo Línea Tx"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> Línea Tx"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3385,8 +3385,8 @@ msgstr "longitudes de onda → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/et.po
+++ b/po/et.po
@@ -1894,8 +1894,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx liini Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx liini Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3362,8 +3362,8 @@ msgstr "lainepikkused → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/fa.po
+++ b/po/fa.po
@@ -1873,8 +1873,8 @@ msgid "Port"
 msgstr "پورت"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo خط انتقال"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> خط انتقال"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3336,8 +3336,8 @@ msgstr "طول‌موج‌ها → مولد"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/fi.po
+++ b/po/fi.po
@@ -1892,8 +1892,8 @@ msgid "Port"
 msgstr "Portti"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Siirtolinjan Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Siirtolinjan Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3365,8 +3365,8 @@ msgstr "aallonpituudet → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1906,8 +1906,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo ligne Tx"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> ligne Tx"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3395,8 +3395,8 @@ msgstr "longueurs d'onde → gén."
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/he.po
+++ b/po/he.po
@@ -1869,8 +1869,8 @@ msgid "Port"
 msgstr "יציאה"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo קו שידור"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> קו שידור"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3324,8 +3324,8 @@ msgstr "אורכי גל → מחולל"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/hi.po
+++ b/po/hi.po
@@ -1874,8 +1874,8 @@ msgid "Port"
 msgstr "पोर्ट"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx Line Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx Line Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3331,8 +3331,8 @@ msgstr "तरंगदैर्घ्य → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/hr.po
+++ b/po/hr.po
@@ -1886,8 +1886,8 @@ msgid "Port"
 msgstr "Priključak"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo prijenosne linije"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> prijenosne linije"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3357,8 +3357,8 @@ msgstr "valne duljine → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/hu.po
+++ b/po/hu.po
@@ -1899,8 +1899,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx vonal Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx vonal Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3385,8 +3385,8 @@ msgstr "hullámhossz → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/id.po
+++ b/po/id.po
@@ -1886,8 +1886,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo Saluran Tx"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> Saluran Tx"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3358,8 +3358,8 @@ msgstr "panjang gelombang → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/it.po
+++ b/po/it.po
@@ -1894,8 +1894,8 @@ msgid "Port"
 msgstr "Porta"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo Linea Tx"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> Linea Tx"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3377,8 +3377,8 @@ msgstr "lunghezze d'onda → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1877,8 +1877,8 @@ msgid "Port"
 msgstr "ポート"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "伝送線路 Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "伝送線路 Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3349,8 +3349,8 @@ msgstr "波長 → 発生源"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/ko.po
+++ b/po/ko.po
@@ -1872,8 +1872,8 @@ msgid "Port"
 msgstr "포트"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "전송선 Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "전송선 Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3338,8 +3338,8 @@ msgstr "파장 → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/ky.po
+++ b/po/ky.po
@@ -1888,8 +1888,8 @@ msgid "Port"
 msgstr "Порт"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Берүү линиясы Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Берүү линиясы Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3361,8 +3361,8 @@ msgstr "толкун узундуктары → ген"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/lt.po
+++ b/po/lt.po
@@ -1889,8 +1889,8 @@ msgid "Port"
 msgstr "Prievadas"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Perd. linijos Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Perd. linijos Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3364,8 +3364,8 @@ msgstr "bangos ilgiai → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/lv.po
+++ b/po/lv.po
@@ -1885,8 +1885,8 @@ msgid "Port"
 msgstr "Ports"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx līnijas Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx līnijas Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3355,8 +3355,8 @@ msgstr "viļņu garumi → ģen."
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/mk.po
+++ b/po/mk.po
@@ -1897,8 +1897,8 @@ msgid "Port"
 msgstr "Порт"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx линија Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx линија Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3376,8 +3376,8 @@ msgstr "бранови должини → ген."
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/ms.po
+++ b/po/ms.po
@@ -1888,8 +1888,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo Talian Tx"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> Talian Tx"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3362,8 +3362,8 @@ msgstr "panjang gelombang → penjana"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/nl.po
+++ b/po/nl.po
@@ -1888,8 +1888,8 @@ msgid "Port"
 msgstr "Poort"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx-lijn Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx-lijn Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3361,8 +3361,8 @@ msgstr "golflengten → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/no.po
+++ b/po/no.po
@@ -1887,8 +1887,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx-linje Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx-linje Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3356,8 +3356,8 @@ msgstr "bølgelengder → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1889,8 +1889,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo linii Tx"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> linii Tx"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3362,8 +3362,8 @@ msgstr "długości fal → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/ps.po
+++ b/po/ps.po
@@ -1876,8 +1876,8 @@ msgid "Port"
 msgstr "پورټ"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "د Tx کرښې Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "د Tx کرښې Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3337,8 +3337,8 @@ msgstr "موج اوږدوالي → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/pt.po
+++ b/po/pt.po
@@ -1890,8 +1890,8 @@ msgid "Port"
 msgstr "Porta"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo Linha Tx"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> Linha Tx"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3371,8 +3371,8 @@ msgstr "comprimentos de onda → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/ro.po
+++ b/po/ro.po
@@ -1901,8 +1901,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo linie Tx"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> linie Tx"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3380,8 +3380,8 @@ msgstr "lungimi de undă → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1893,8 +1893,8 @@ msgid "Port"
 msgstr "Порт"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo линии передачи"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> линии передачи"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3364,8 +3364,8 @@ msgstr "длины волн → ген."
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/sk.po
+++ b/po/sk.po
@@ -1884,8 +1884,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo vedenia Tx"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> vedenia Tx"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3351,8 +3351,8 @@ msgstr "vlnové dĺžky → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/sl.po
+++ b/po/sl.po
@@ -1857,8 +1857,8 @@ msgid "Port"
 msgstr "Vrata"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo prenosne linije"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> prenosne linije"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3327,8 +3327,8 @@ msgstr "valovne dolžine → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/sr.po
+++ b/po/sr.po
@@ -1884,8 +1884,8 @@ msgid "Port"
 msgstr "Порт"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo преносне линије"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> преносне линије"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3352,8 +3352,8 @@ msgstr "таласне дужине → ген"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1886,8 +1886,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx-linje Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx-linje Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3355,8 +3355,8 @@ msgstr "våglängder → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/ta.po
+++ b/po/ta.po
@@ -1883,8 +1883,8 @@ msgid "Port"
 msgstr "போர்ட்"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx கோடு Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx கோடு Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3352,8 +3352,8 @@ msgstr "அலைநீளங்கள் → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/th.po
+++ b/po/th.po
@@ -1854,8 +1854,8 @@ msgid "Port"
 msgstr "พอร์ต"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo สายส่ง"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> สายส่ง"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3308,8 +3308,8 @@ msgstr "ความยาวคลื่น → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/tr.po
+++ b/po/tr.po
@@ -1889,8 +1889,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "İletim Hattı Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "İletim Hattı Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3366,8 +3366,8 @@ msgstr "dalga boyları → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/uk.po
+++ b/po/uk.po
@@ -1890,8 +1890,8 @@ msgid "Port"
 msgstr "Порт"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo лінії передачі"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> лінії передачі"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3363,8 +3363,8 @@ msgstr "довжини хвиль → ген"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/ur.po
+++ b/po/ur.po
@@ -1879,8 +1879,8 @@ msgid "Port"
 msgstr "پورٹ"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Tx Line Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Tx Line Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3345,8 +3345,8 @@ msgstr "طول موج → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/uz.po
+++ b/po/uz.po
@@ -1892,8 +1892,8 @@ msgid "Port"
 msgstr "Port"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Uzatish liniyasi Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Uzatish liniyasi Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3373,8 +3373,8 @@ msgstr "toʻlqin uzunliklari → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/vi.po
+++ b/po/vi.po
@@ -1882,8 +1882,8 @@ msgid "Port"
 msgstr "Cổng"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "Zo đường truyền"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "Z<sub>0</sub> đường truyền"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3352,8 +3352,8 @@ msgstr "bước sóng → gen"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1827,8 +1827,8 @@ msgid "Port"
 msgstr "端口"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "传输线 Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "传输线 Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3277,8 +3277,8 @@ msgstr "波长 → 电源"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1826,8 +1826,8 @@ msgid "Port"
 msgstr "埠"
 
 #: resources/xnec2c.glade:10123
-msgid "Tx Line Zo"
-msgstr "傳輸線 Zo"
+msgid "Tx Line Z<sub>0</sub>"
+msgstr "傳輸線 Z<sub>0</sub>"
 
 #: resources/xnec2c.glade:10137 resources/xnec2c.glade:11718
 #: resources/xnec2c.glade:12952
@@ -3276,8 +3276,8 @@ msgstr "波長 → 訊號源"
 
 #: src/freqplots/graphs/smith_graph.c:507
 #, c-format
-msgid "Z0 = %g Ω"
-msgstr "Z0 = %g Ω"
+msgid "Z₀ = %g Ω"
+msgstr "Z₀ = %g Ω"
 
 #: src/freqplots/graphs/smith_graph.c:514
 msgid "INDUCTIVE (+jX)"


### PR DESCRIPTION
## Summary

`make check` fails on master because two source strings changed without updating the translation catalogs. The `check-po-catalogs` gate (added in dba2091) catches the resulting fuzzy entries that `msgmerge` introduces during the build:

```
./po/af.po: FAIL 2 fuzzy entries remain
./po/af.po: FAIL fuzzy entry at line 1890
./po/af.po: FAIL fuzzy entry at line 3365
```

The gate was added *after* the string changes landed, so the pre-existing debt now blocks `make check` (and any packaging that runs it). `af` is first in `LINGUAS`, but all 47 catalogs carry the same stale entries.

### Stale entry 1 — `resources/xnec2c.glade:10123`
```
"Tx Line Zo" -> "Tx Line Z<sub>0</sub>"
```
From `2da158f` (rename ZO mnemonic to Z0). Each msgstr's impedance symbol `Zo` is replaced with `Z<sub>0</sub>`, preserving per-language word order and translated segments (e.g. `es` keeps `Z<sub>0</sub> Línea Tx`, `de` keeps `Tx-Leitung Z<sub>0</sub>`).

### Stale entry 2 — `src/freqplots/graphs/smith_graph.c:507`
```
"Z0 = %g Ω" -> "Z₀ = %g Ω"
```
The formula is identical in every catalog, so `Z0` → `Z₀` in both msgid and msgstr. The `#, c-format` flag is retained.

## Verification

On a clean build of master with this commit applied:

- `msgmerge` against `po/xnec2c.pot` produces **0 fuzzy entries** for all 47 languages (was 2 per file).
- `make check-po-catalogs` — **pass** (was FAIL)
- `make check-examples-file-list` — **pass**
- `make check-potfiles-list` — **pass**
- `make -C t check` — **11/11 pass**
- Full `make check` — **pass** (was exit 2)

The diff is mechanical: exactly 4 lines per file (msgid + msgstr × 2 strings), 188 insertions / 188 deletions across 47 files. No translation content is rewritten — only the impedance symbol markup is updated to match the current source strings.