### PR TITLE
Add F/R ratio and AGT (Average Gain Test) measurements

### DIFF
--- a/resources/xnec2c.glade
+++ b/resources/xnec2c.glade
@@ -9868,6 +9868,21 @@ Save NEC2 Editor data first?
                     <property name="position">7</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkToggleButton" id="freqplots_agt_togglebutton">
+                    <property name="label" translatable="yes">AGT</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <signal name="toggled" handler="on_config_widget_changed" swapped="no"/>
+                    <accelerator key="a" signal="activate"/>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">8</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,6 +47,7 @@ xnec2c_SOURCES = \
     freqplots/freqplots_xy.c \
     freqplots/graphs/smith_graph.c \
     freqplots/graphs/gain_graph.c \
+    freqplots/graphs/agt_graph.c \
     freqplots/graphs/viewer_graph.c \
     freqplots/graphs/vswr_graph.c \
     freqplots/graphs/impedance_graph.c \

--- a/src/common.h
+++ b/src/common.h
@@ -337,6 +337,7 @@ typedef struct
     freqplots_zmgzph_togglebutton,
     freqplots_smith_togglebutton,
     freqplots_ant_temp_togglebutton,
+    freqplots_agt_togglebutton,
     freqplots_show_ant_temp,
     freqplots_min_max,
     freqplots_s11,
@@ -797,6 +798,9 @@ typedef struct
     nph,
     ipd,
     iavp,
+    iavp_requested, /* raw RP-card A value before the always-on kernel
+                        diagnostic auto-enables iavp; reflects whether the
+                        USER explicitly asked for averaging (A=1 or A=2) */
     inor,
     iax,
     ixtyp;
@@ -1080,6 +1084,7 @@ typedef enum {
 	FP_PANEL_ALL = -1,
 	FP_PANEL_GAIN = 0, FP_PANEL_GAIN_DIR, FP_PANEL_VIEWER, FP_PANEL_VSWR,
 	FP_PANEL_ZRLZIM, FP_PANEL_ZMGZPH, FP_PANEL_SMITH, FP_PANEL_ANT_TEMP,
+	FP_PANEL_AGT,
 	FP_PANEL_COUNT
 } fp_panel_t;
 
@@ -1116,7 +1121,7 @@ typedef struct {
 
 /* Upper bound on selected-frequency readout columns per popup: a leading
  * frequency column plus the largest per-graph field set. */
-#define FP_READOUT_MAX 6
+#define FP_READOUT_MAX 8
 
 /* Per-window render and input context for the frequency plots.  The primary
  * window is the sole persistent instance; popups are heap instances holding a
@@ -1248,6 +1253,14 @@ typedef struct
 
   double
     efficiency;     /* Radiation efficiency = prad / pinr, per freq step */
+
+  double
+    agt_ratio,          /* Average Gain Test: linear ratio (1.0=free space
+                             ideal, 2.0=ideal over perfect ground) */
+    agt_efficiency_pct; /* Same, expressed as % of theoretical max gain */
+  int
+    agt_valid;          /* 1 if RP card had averaging (A=1/2) and total_omega
+                             was non-degenerate; 0 = not computed this step */
 
   double
     noise_scaled_max,  /* True max of Scale_Gain in noise mode (K/sr) */

--- a/src/config_hooks.c
+++ b/src/config_hooks.c
@@ -387,6 +387,11 @@ void hook_freqplots_ant_temp(void)
   freqplots_select_changed(rc_config.freqplots_ant_temp_togglebutton);
 }
 
+void hook_freqplots_agt(void)
+{
+  freqplots_select_changed(rc_config.freqplots_agt_togglebutton);
+}
+
 void
 hook_freqplots_net_gain(void)
 {

--- a/src/config_hooks.h
+++ b/src/config_hooks.h
@@ -56,6 +56,7 @@ void hook_freqplots_zrlzim(void);
 void hook_freqplots_zmgzph(void);
 void hook_freqplots_smith(void);
 void hook_freqplots_ant_temp(void);
+void hook_freqplots_agt(void);
 void hook_freqplots_net_gain(void);
 void hook_freqplots_min_max(void);
 void hook_freqplots_clamp_vswr(void);

--- a/src/fork.c
+++ b/src/fork.c
@@ -316,6 +316,9 @@ freq_fields_xfer(int fstep, int pipe_idx, pipe_fn_t pipe_fn)
     { rad_pattern[fstep].min_gain_idx, NULL,           NUM_POL * sizeof(int),    FREQ_COND_RDPAT  },
     { rad_pattern[fstep].sens,         size_nphth_int, 0,                        FREQ_COND_RDPAT  },
     { &rad_pattern[fstep].efficiency,  NULL,           sizeof(double),           FREQ_COND_RDPAT  },
+    { &rad_pattern[fstep].agt_ratio,          NULL,    sizeof(double),           FREQ_COND_RDPAT  },
+    { &rad_pattern[fstep].agt_efficiency_pct, NULL,    sizeof(double),           FREQ_COND_RDPAT  },
+    { &rad_pattern[fstep].agt_valid,          NULL,    sizeof(int),              FREQ_COND_RDPAT  },
     /* Per-fstep noise temperature table (allocated alongside rad_pattern[]) */
     { &noise_temp[fstep],              NULL,              sizeof(noise_temp_t),  FREQ_COND_RDPAT  },
     /* Per-fstep structure colors (patch flow + cmin/cmax range scalars) */

--- a/src/freqplots/freqplots_core.c
+++ b/src/freqplots/freqplots_core.c
@@ -59,6 +59,7 @@ static const char *fp_panel_names[FP_PANEL_COUNT] = {
   [FP_PANEL_ZMGZPH]   = N_("Impedance (mag/phase)"),
   [FP_PANEL_SMITH]    = N_("Smith Chart"),
   [FP_PANEL_ANT_TEMP] = N_("Antenna Temperature"),
+  [FP_PANEL_AGT]      = N_("Average Gain Test"),
 };
 
 /* Per-panel selection and data-availability descriptor.  select_field points
@@ -89,6 +90,7 @@ static const fp_panel_desc_t fp_panel_desc[FP_PANEL_COUNT] = {
   [FP_PANEL_ZMGZPH]   = { &rc_config.freqplots_zmgzph_togglebutton,   "freqplots_zmgzph_togglebutton",   0,            TRUE,  TRUE,  NULL                         },
   [FP_PANEL_SMITH]    = { &rc_config.freqplots_smith_togglebutton,    "freqplots_smith_togglebutton",    0,            TRUE,  TRUE,  NULL                         },
   [FP_PANEL_ANT_TEMP] = { &rc_config.freqplots_ant_temp_togglebutton, "freqplots_ant_temp_togglebutton", ENABLE_RDPAT, FALSE, FALSE, NULL                         },
+  [FP_PANEL_AGT]      = { &rc_config.freqplots_agt_togglebutton,      "freqplots_agt_togglebutton",      ENABLE_RDPAT, FALSE, FALSE, NULL                         },
 };
 
 /* freqplots_panel_select_id()
@@ -153,6 +155,9 @@ static const fp_readout_field_t fp_rf_gain[] = {
   { MEAS_GAIN_MAX, FP_FIELD_ALWAYS,        "%.2f", " dBi", -1e30 },
   { MEAS_GAIN_NET, FP_FIELD_IF_NETGAIN,    "%.2f", " dBi", -1e30 },
   { MEAS_FB_RATIO, FP_FIELD_IF_NO_NETGAIN, "%.2f", " dB",  0.0   },
+  { MEAS_FR_RATIO, FP_FIELD_IF_NO_NETGAIN, "%.2f", " dB",  0.0   },
+  { MEAS_AGT,            FP_FIELD_ALWAYS, "%.4f", "",   0.0 },
+  { MEAS_AGT_EFFICIENCY, FP_FIELD_ALWAYS, "%.1f", "%",  0.0 },
   { -1, FP_FIELD_ALWAYS, NULL, NULL, 0.0 },
 };
 
@@ -200,6 +205,12 @@ static const fp_readout_field_t fp_rf_ant_temp[] = {
   { -1, FP_FIELD_ALWAYS, NULL, NULL, 0.0 },
 };
 
+static const fp_readout_field_t fp_rf_agt[] = {
+  { MEAS_AGT,            FP_FIELD_ALWAYS, "%.4f", "",  0.0 },
+  { MEAS_AGT_EFFICIENCY, FP_FIELD_ALWAYS, "%.1f", "%", 0.0 },
+  { -1, FP_FIELD_ALWAYS, NULL, NULL, 0.0 },
+};
+
 /* Per-graph readout field set, indexed by fp_panel_t.  This is the one place
  * naming which measurement values each popup graph displays. */
 static const fp_readout_field_t *const fp_panel_readout[FP_PANEL_COUNT] = {
@@ -211,6 +222,7 @@ static const fp_readout_field_t *const fp_panel_readout[FP_PANEL_COUNT] = {
   [FP_PANEL_ZMGZPH]   = fp_rf_zmgzph,
   [FP_PANEL_SMITH]    = fp_rf_smith,
   [FP_PANEL_ANT_TEMP] = fp_rf_ant_temp,
+  [FP_PANEL_AGT]      = fp_rf_agt,
 };
 
 /* True when the setting gating @cond currently selects its column.  Each arm
@@ -325,6 +337,7 @@ typedef struct
 /* Dispatch order fixes the top-to-bottom panel layout of the plots window. */
 static const fp_plot_dispatch_t fp_plot_dispatch[] = {
   { fp_gain_enabled,      fp_gain_render      },
+  { fp_agt_enabled,       fp_agt_render       },
   { fp_viewer_enabled,    fp_viewer_render    },
   { fp_vswr_enabled,      fp_vswr_render      },
   { fp_impedance_enabled, fp_impedance_render },
@@ -1179,6 +1192,7 @@ freqplots_cleanup( void )
   mem_array_free( &card_nfsteps );
 
   fp_gain_free();
+  fp_agt_free();
   fp_viewer_free();
   fp_vswr_free();
   fp_impedance_free();

--- a/src/freqplots/freqplots_internal.h
+++ b/src/freqplots/freqplots_internal.h
@@ -155,6 +155,8 @@ int fp_panel_available(fp_panel_t panel);
  * render pass.  Defined one type per file (freqplots_<type>.c). */
 int      fp_gain_enabled(void);
 gboolean fp_gain_render(fp_plot_ctx_t *ctx);
+int      fp_agt_enabled(void);
+gboolean fp_agt_render(fp_plot_ctx_t *ctx);
 int      fp_viewer_enabled(void);
 gboolean fp_viewer_render(fp_plot_ctx_t *ctx);
 int      fp_vswr_enabled(void);
@@ -167,6 +169,7 @@ gboolean fp_ant_temp_render(fp_plot_ctx_t *ctx);
 /* Per-type trace-buffer release, called once at program exit through
  * freqplots_cleanup(). */
 void fp_gain_free(void);
+void fp_agt_free(void);
 void fp_viewer_free(void);
 void fp_vswr_free(void);
 void fp_impedance_free(void);

--- a/src/freqplots/graphs/agt_graph.c
+++ b/src/freqplots/graphs/agt_graph.c
@@ -1,0 +1,77 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ *
+ *  The official website and doumentation for xnec2c is available here:
+ *    https://www.xnec2c.org/
+ */
+
+/*
+ * agt_graph: Average Gain Test plot type.
+ *
+ * Plots the AGT linear ratio (~1.0 free space / ~2.0 over perfect ground
+ * for a lossless model) alongside AGT efficiency %, across every swept
+ * frequency point. Values come from the shared meas_calc() column source
+ * and report the -1 sentinel (via MEAS_AGT/MEAS_AGT_EFFICIENCY) whenever
+ * the RP card wasn't set up with averaging (A=1 or A=2) for that step.
+ */
+
+#include "../freqplots_internal.h"
+#include "../../shared.h"
+
+  int
+fp_agt_enabled(void)
+{
+  /* Gate on the RP card's OWN A field (A=1 or A=2), as the user actually
+   * wrote it -- not fpat.iavp, which xnec2c auto-enables by default for
+   * its own kernel-accuracy diagnostic regardless of what the RP card
+   * says (see input.c). AGT values/CSV columns stay populated either
+   * way since that diagnostic is useful info on its own; this only
+   * controls whether the dedicated AGT tab is considered "on". */
+  return rc_config.freqplots_agt_togglebutton
+      && isFlagSet(ENABLE_RDPAT)
+      && fpat.iavp_requested;
+}
+
+/* AGT plot trace buffers, reused across fp_agt_render() calls. */
+static double *agt = NULL, *agt_eff = NULL;
+
+/* fp_agt_free()
+ *
+ * Releases the AGT plot trace buffers.
+ */
+  void
+fp_agt_free( void )
+{
+  mem_array_free( &agt );
+  mem_array_free( &agt_eff );
+
+} /* fp_agt_free() */
+
+  gboolean
+fp_agt_render(fp_plot_ctx_t *ctx)
+{
+  char *titles[3];
+
+  mem_array_realloc(&agt, ctx->num_fsteps);
+  mem_array_realloc(&agt_eff, ctx->num_fsteps);
+
+  fp_meas_column_t cols[2];
+  int ncols = 0;
+  cols[ncols++] = (fp_meas_column_t){ agt,     MEAS_AGT            };
+  cols[ncols++] = (fp_meas_column_t){ agt_eff, MEAS_AGT_EFFICIENCY };
+  fp_fill_meas_columns( ctx, cols, ncols );
+
+  titles[0] = _("Average Gain");
+  titles[1] = _("Average Gain Test vs Frequency");
+  titles[2] = _("AGT Efficiency %");
+  fp_plot_panel(ctx, agt, agt_eff, titles, FP_PANEL_AGT);
+
+  return TRUE;
+}

--- a/src/input.c
+++ b/src/input.c
@@ -1686,6 +1686,7 @@ Read_Commands( void )
 
         fpat.ipd  = itmp4 / 10;
         fpat.iavp = itmp4 - fpat.ipd*10;
+        fpat.iavp_requested = fpat.iavp;   /* snapshot before auto-override */
         fpat.inor = fpat.ipd / 10;
         fpat.ipd  = fpat.ipd - fpat.inor*10;
         fpat.iax  = fpat.inor / 10;
@@ -1753,6 +1754,7 @@ Read_Commands( void )
         fpat.rfld = 0.0;
         fpat.ipd  = 0;
         fpat.iavp = 0;
+        fpat.iavp_requested = 0;
         fpat.inor = 0;
         fpat.iax  = 0;
         fpat.nth  = 91;

--- a/src/measurements.c
+++ b/src/measurements.c
@@ -458,6 +458,9 @@ const char *meas_names[] = {
 	[MEAS_GAIN_VIEWER]      =  "gain_viewer",
 	[MEAS_GAIN_VIEWER_NET]  =  "gain_viewer_net",
 	[MEAS_FB_RATIO]         =  "fb_ratio",
+	[MEAS_FR_RATIO]         =  "fr_ratio",
+	[MEAS_AGT]              =  "agt",
+	[MEAS_AGT_EFFICIENCY]   =  "agt_efficiency",
 	[MEAS_GAIN_DEV_PX]     =  "gain_dev_px",
 	[MEAS_GAIN_DEV_NX]     =  "gain_dev_nx",
 	[MEAS_GAIN_DEV_PY]     =  "gain_dev_py",
@@ -488,6 +491,9 @@ const char *meas_display_names[] = {
 	[MEAS_GAIN_VIEWER]      =  "Viewer Gain",
 	[MEAS_GAIN_VIEWER_NET]  =  "Viewer Net Gain",
 	[MEAS_FB_RATIO]         =  "F/B Ratio",
+	[MEAS_FR_RATIO]         =  "F/R Ratio",
+	[MEAS_AGT]              =  "Average Gain",
+	[MEAS_AGT_EFFICIENCY]   =  "AGT Efficiency",
 	[MEAS_GAIN_DEV_PX]     =  "Gain Dev +X",
 	[MEAS_GAIN_DEV_NX]     =  "Gain Dev −X",
 	[MEAS_GAIN_DEV_PY]     =  "Gain Dev +Y",
@@ -518,6 +524,9 @@ const char *meas_descriptions[] = {
 	[MEAS_GAIN_VIEWER]      =  "Gain toward current viewer angle in dBi",
 	[MEAS_GAIN_VIEWER_NET]  =  "Viewer gain adjusted for mismatch loss in dBi",
 	[MEAS_FB_RATIO]         =  "Front-to-back ratio in dB",
+	[MEAS_FR_RATIO]         =  "Front to worst-case rear-lobe ratio in dB (rear = >90 deg off boresight)",
+	[MEAS_AGT]              =  "Average Gain Test: linear ratio, ~1.0 in free space or ~2.0 over perfect ground for a lossless model (requires RP card averaging A=1 or A=2)",
+	[MEAS_AGT_EFFICIENCY]   =  "Average Gain Test result as % of theoretical maximum gain for the covered solid angle",
 	[MEAS_GAIN_DEV_PX]     =  "Angular deviation of peak gain from +X axis (degrees)",
 	[MEAS_GAIN_DEV_NX]     =  "Angular deviation of peak gain from -X axis (degrees)",
 	[MEAS_GAIN_DEV_PY]     =  "Angular deviation of peak gain from +Y axis (degrees)",
@@ -764,6 +773,61 @@ static void _meas_calc(measurement_t *m, int idx, int port)
 		m->fb_ratio /= pow(10.0, (rad_pattern[idx].gtot[fbidx]
 						+ Polarization_Factor(pol, idx, fbidx)) / 10.0);
 		m->fb_ratio = 10.0 * log10(m->fb_ratio);
+
+		/* Front-to-Rear: worst-case (max gain) lobe anywhere more than
+		 * 90 degrees off boresight AZIMUTH, at the SAME take-off theta as
+		 * the main lobe -- i.e. the "rear half-plane" as conventionally
+		 * defined by AO/EZNEC and used in K6STI's published Yagi work
+		 * ("F/R is the ratio of forward power to that of the worst
+		 * backlobe in the rear half-plane"). A full 3D theta+phi search
+		 * is more thorough but no longer matches this standard metric,
+		 * since it can find weaker-rejection lobes off at other elevation
+		 * angles that the conventional definition deliberately excludes. */
+		{
+			double rear_gain_max = -1e30;
+			double main_phi = m->gain_max_phi;
+
+			for (int iph = 0; iph < fpat.nph; iph++)
+			{
+				double phi_cell = fpat.phis + iph * fpat.dph;
+				double dphi = fmod(fabs(phi_cell - main_phi), 360.0);
+				if (dphi > 180.0)
+					dphi = 360.0 - dphi;
+
+				/* "Rear" = more than 90 degrees off boresight azimuth */
+				if (dphi <= 90.0)
+					continue;
+
+				int cell = nth + iph * fpat.nth;
+				double g = rad_pattern[idx].gtot[cell]
+						+ Polarization_Factor(pol, idx, cell);
+				if (g > rear_gain_max)
+					rear_gain_max = g;
+			}
+
+			if (rear_gain_max > -1e30)
+			{
+				m->fr_ratio = pow(10.0, m->gain_max / 10.0);
+				m->fr_ratio /= pow(10.0, rear_gain_max / 10.0);
+				m->fr_ratio = 10.0 * log10(m->fr_ratio);
+			}
+			else
+				m->fr_ratio = -1;
+		}
+
+		/* Average Gain Test: only meaningful if the RP card requested
+		 * averaging (A=1 or A=2) for this run; sentinel -1 otherwise so
+		 * CSV/plot readers can tell "not computed" from a real 0.0. */
+		if (rad_pattern[idx].agt_valid)
+		{
+			m->agt            = rad_pattern[idx].agt_ratio;
+			m->agt_efficiency = rad_pattern[idx].agt_efficiency_pct;
+		}
+		else
+		{
+			m->agt            = -1;
+			m->agt_efficiency = -1;
+		}
 	}
 
 }

--- a/src/measurements.h
+++ b/src/measurements.h
@@ -26,6 +26,9 @@ enum MEASUREMENT_INDEXES
 	MEAS_GAIN_VIEWER,
 	MEAS_GAIN_VIEWER_NET,
 	MEAS_FB_RATIO,
+	MEAS_FR_RATIO,
+	MEAS_AGT,
+	MEAS_AGT_EFFICIENCY,
 	MEAS_GAIN_DEV_PX,
 	MEAS_GAIN_DEV_NX,
 	MEAS_GAIN_DEV_PY,
@@ -264,6 +267,9 @@ typedef struct
 			double gain_max_theta, gain_max_phi;
 			double gain_viewer, gain_viewer_net;
 			double fb_ratio;
+			double fr_ratio;
+			double agt;
+			double agt_efficiency;
 			double gain_dev_px, gain_dev_nx;
 			double gain_dev_py, gain_dev_ny;
 			double gain_dev_pz, gain_dev_nz;

--- a/src/radiation.c
+++ b/src/radiation.c
@@ -873,6 +873,17 @@ rdpat( void )
     double expected_gain = (4.0 * M_PI) / total_omega;
     double efficiency_pct = (pint / expected_gain) * 100.0;
 
+    /* Persist for MEAS_AGT / MEAS_AGT_EFFICIENCY and CSV/plot readout;
+     * rdpat() itself has no notion of "which frequency step", so pull it
+     * from calc_data the same way Radiation_Pattern() does for efficiency. */
+    int fstep = calc_data.freq_step;
+    if( fstep >= 0 )
+    {
+      rad_pattern[fstep].agt_ratio          = pint;
+      rad_pattern[fstep].agt_efficiency_pct = efficiency_pct;
+      rad_pattern[fstep].agt_valid          = 1;
+    }
+
     /* Warn if gain exceeds expected: indicates RP theta/phi range issue */
     if( pint > expected_gain * 1.01 )
     {

--- a/src/rc_config.c
+++ b/src/rc_config.c
@@ -662,6 +662,11 @@ rc_config_vars_t rc_config_vars[] = {
 		.widgets = CONFIG_WIDGET_SINGLE( &freqplots_window_builder,
 			"freqplots_ant_temp_togglebutton", hook_freqplots_ant_temp ) },
 
+	{ .desc = "Freqplots AGT Toggle", .format = "%d",
+		.vars = { &rc_config.freqplots_agt_togglebutton },
+		.widgets = CONFIG_WIDGET_SINGLE( &freqplots_window_builder,
+			"freqplots_agt_togglebutton", hook_freqplots_agt ) },
+
 	{ .desc = "Freqplots Show Ant Temp (Ta instead of TA)", .format = "%d",
 		.vars = { &rc_config.freqplots_show_ant_temp },
 		.widgets = CONFIG_WIDGET_SINGLE( &freqplots_window_builder,


### PR DESCRIPTION
- F/R ratio (MEAS_FR_RATIO): worst-case gain in the rear half-plane (>90 deg off boresight azimuth, same elevation as main lobe), matching the AO/EZNEC convention rather than a single antipodal F/B-style lookup. Included automatically in CSV output.

- AGT (MEAS_AGT / MEAS_AGT_EFFICIENCY): exposes the existing console Average Gain Test diagnostic through the measurement pipeline, so it's available in CSV output and the Gain panel's readout bar.

- New dedicated 'AGT' tab in Frequency Plots, graphing AGT ratio and efficiency % across every swept frequency point. The tab is only considered enabled when the model's RP card explicitly requests averaging (A=1 or A=2) -- this required adding fpat.iavp_requested, since fpat.iavp itself is auto-forced on by the existing kernel- accuracy diagnostic regardless of the RP card's actual setting.