### PR TITLE
Add Tag/Seg number overlay and keyboard panning to structure view

### DIFF
--- a/resources/xnec2c.glade
+++ b/resources/xnec2c.glade
@@ -10871,6 +10871,15 @@ Save NEC2 Editor data first?
                           </object>
                         </child>
                         <child>
+                          <object class="GtkCheckMenuItem" id="main_show_seg_labels">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Show Tag/_Seg Numbers</property>
+                            <property name="use-underline">True</property>
+                            <signal name="toggled" handler="on_main_show_seg_labels_toggled" swapped="no"/>
+                          </object>
+                        </child>
+                        <child>
                           <object class="GtkMenuItem" id="main_pol_menu">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>

--- a/src/cairo/cairo_draw.h
+++ b/src/cairo/cairo_draw.h
@@ -41,6 +41,14 @@ typedef struct
 
 #define AXIS_COUNT 3
 
+/* Deferred per-segment Tag/Seg number label (owns its formatted text,
+ * since (unlike axis labels) the string differs for every segment). */
+typedef struct
+{
+  int  x, y;       /* screen position (segment midpoint) */
+  char text[20];   /* e.g. "T12/S345" */
+} seg_label_t;
+
 typedef struct
 {
   /* Caller-provided frame resources */
@@ -51,6 +59,10 @@ typedef struct
   /* Render-internal fields (set during render(), consumed by render_cairo) */
   axis_label_t     axis_labels[AXIS_COUNT];
   int              n_axis_labels;
+  seg_label_t     *seg_labels;      /* malloc'd by cairo_draw_structure(),
+                                        freed by render_cairo() after flush */
+  int              n_seg_labels;
+  double           seg_label_font_pt; /* zoom-scaled font size for the above */
   const char      *status_message; /* deferred status text; painted after flush */
   cairo_surface_t *gradient;       /* resolved gradient legend; NULL = skip */
 } cairo_render_ctx_t;

--- a/src/cairo/cairo_frame.c
+++ b/src/cairo/cairo_frame.c
@@ -134,6 +134,31 @@ render_cairo(cairo_render_ctx_t *ctx, const render_ops_t *ops)
     g_object_unref(layout);
   }
 
+  /* Draw deferred per-segment Tag/Seg number labels, then release the
+   * array allocated fresh each frame by cairo_draw_structure(). */
+  if( ctx->n_seg_labels > 0 && ctx->seg_labels != NULL )
+  {
+    PangoLayout *layout = gtk_widget_create_pango_layout(structure_drawingarea, NULL);
+    char font_str[16];
+    snprintf(font_str, sizeof(font_str), "Sans %.1f", ctx->seg_label_font_pt);
+    PangoFontDescription *pfd = pango_font_description_from_string(font_str);
+    int k;
+
+    pango_layout_set_font_description(layout, pfd);
+    cairo_set_source_rgb(cr, 1.0, 1.0, 0.0); /* yellow: readable over most wire colors */
+    for( k = 0; k < ctx->n_seg_labels; k++ )
+    {
+      pango_layout_set_text(layout, ctx->seg_labels[k].text, -1);
+      cairo_move_to(cr, (double)ctx->seg_labels[k].x,
+          (double)ctx->seg_labels[k].y);
+      pango_cairo_show_layout(cr, layout);
+    }
+    pango_font_description_free(pfd);
+    g_object_unref(layout);
+  }
+  free(ctx->seg_labels);
+  ctx->seg_labels = NULL;
+
   /* Gradient legend surface resolved by render() via set_gradient callback;
    * non-NULL only when farfield mode is active on the rdpattern view. */
   if( ctx->gradient != NULL )

--- a/src/cairo/cairo_structure.c
+++ b/src/cairo/cairo_structure.c
@@ -374,6 +374,53 @@ cairo_draw_structure(void *ctx, float extent,
   draw_surface_patches(cc->sb, v, scale, structure_segs + data.n, data.m, params);
   draw_wire_segments(cc->sb, v, structure_segs, data.n, params);
 
+  /* Deferred Tag/Seg number labels: one per wire segment, drawn after the
+   * scenebuffer flush (see render_cairo()) so text sits on top of lines
+   * regardless of depth-sort order. Skipped when the toggle is off, and
+   * silently skipped (not fatal) if the allocation fails. */
+  cc->seg_labels   = NULL;
+  cc->n_seg_labels = 0;
+  if( show_seg_labels && data.n > 0 )
+  {
+    seg_label_t *labels = malloc( (size_t)data.n * sizeof(seg_label_t) );
+    if( labels != NULL )
+    {
+      int idx;
+      int prev_tag    = -1;   /* sentinel: no real NEC tag is negative */
+      int seg_in_tag  = 0;    /* 1-based position within the current tag's run */
+
+      for( idx = 0; idx < data.n; idx++ )
+      {
+        int this_tag = data.segments[idx].itag;
+
+        /* Segments belonging to one GW card share a tag and are laid out
+         * contiguously, so a simple "reset on tag change" counter gives
+         * per-wire segment numbering (1, 2, 3...) without needing a
+         * hash/lookup table for the (uncommon) non-contiguous case. */
+        if( this_tag != prev_tag )
+        {
+          seg_in_tag = 1;
+          prev_tag   = this_tag;
+        }
+        else
+          seg_in_tag++;
+
+        labels[idx].x = (structure_segs[idx].x1 + structure_segs[idx].x2) / 2;
+        labels[idx].y = (structure_segs[idx].y1 + structure_segs[idx].y2) / 2;
+        snprintf( labels[idx].text, sizeof(labels[idx].text),
+            "T%d/S%d", this_tag, seg_in_tag );
+      }
+      cc->seg_labels   = labels;
+      cc->n_seg_labels = data.n;
+    }
+
+    /* Font size tracks zoom (100% -> 7pt baseline), clamped so labels stay
+     * legible at extreme zoom-out and don't overwhelm the view zoomed in. */
+    cc->seg_label_font_pt = 7.0 * (v->zoom / 100.0);
+    if( cc->seg_label_font_pt < 4.0)  cc->seg_label_font_pt = 4.0;
+    if( cc->seg_label_font_pt > 24.0) cc->seg_label_font_pt = 24.0;
+  }
+
   return TRUE;
 }
 

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -220,6 +220,39 @@ on_main_window_key_press_event(
         return( TRUE );
     }
   }
+
+  /* Arrow keys pan the structure view (screen-space translate), matching
+   * the same view_apply_pan_delta() path middle-mouse-drag panning uses.
+   * Hold Shift for a larger step. Directions mirror drag: Right/Down
+   * move the structure the same way dragging the mouse right/down would. */
+  {
+    const float PAN_STEP_PX      = 15.0f;
+    const float PAN_STEP_PX_FAST = 60.0f;
+    float step = (event->state & GDK_SHIFT_MASK) ? PAN_STEP_PX_FAST : PAN_STEP_PX;
+
+    if( structure_view != NULL )
+    {
+      switch( event->keyval )
+      {
+        case GDK_KEY_Left:
+          view_apply_pan_delta( structure_view, -step, 0.0f );
+          return( TRUE );
+
+        case GDK_KEY_Right:
+          view_apply_pan_delta( structure_view, step, 0.0f );
+          return( TRUE );
+
+        case GDK_KEY_Up:
+          view_apply_pan_delta( structure_view, 0.0f, -step );
+          return( TRUE );
+
+        case GDK_KEY_Down:
+          view_apply_pan_delta( structure_view, 0.0f, step );
+          return( TRUE );
+      }
+    }
+  }
+
   return( FALSE );
 }
 
@@ -630,6 +663,16 @@ freqplots_connect_panel_buttons( GtkBuilder *builder )
         G_CALLBACK(freqplots_panel_button_press_cb),
         GINT_TO_POINTER(p) );
   }
+}
+
+
+  void
+on_main_show_seg_labels_toggled(
+    GtkCheckMenuItem *menuitem,
+    gpointer          user_data)
+{
+  show_seg_labels = gtk_check_menu_item_get_active( menuitem );
+  xnec2_widget_queue_draw( structure_drawingarea, TRUE );
 }
 
 

--- a/src/common.h
+++ b/src/common.h
@@ -1361,6 +1361,7 @@ void on_struct_save_as_gnuplot_activate(GtkMenuItem *menuitem, gpointer user_dat
 void on_optimizer_output_toggled(GtkMenuItem *menuitem, gpointer user_data);
 void on_quit_activate(GtkMenuItem *menuitem, gpointer user_data);
 void on_main_rdpattern_activate(GtkMenuItem *menuitem, gpointer user_data);
+void on_main_show_seg_labels_toggled(GtkCheckMenuItem *menuitem, gpointer user_data);
 void on_main_freqplots_activate(GtkMenuItem *menuitem, gpointer user_data);
 void on_view_preset_clicked(GtkButton *button, gpointer user_data);
 void on_main_rotate_spinbutton_value_changed(GtkSpinButton *spinbutton, gpointer user_data);

--- a/src/shared.c
+++ b/src/shared.c
@@ -190,6 +190,7 @@ GRecMutex freq_data_lock;
 
 /* Program forked flag */
 gboolean FORKED = FALSE;
+gboolean show_seg_labels = FALSE;
 
 /* Used to kill window deleted by user */
 GtkWidget *kill_window = NULL;

--- a/src/shared.h
+++ b/src/shared.h
@@ -56,6 +56,7 @@ static inline int rdpat_ehfield_active(void)
 
 /* Flag to control verify_segments check */
 extern gboolean skip_verify_segments;
+extern gboolean show_seg_labels;
 
 extern char *orig_numeric_locale;
 


### PR DESCRIPTION
- New 'View > Show Tag/Seg Numbers' toggle: overlays each wire segment's tag and per-tag-relative segment number (T{tag}/S{n}, n resets to 1 per tag) at its screen midpoint. Useful for correlating kernel length/radius-ratio warnings or convergence issues back to specific wires without cross-referencing the geometry tree by hand.

- Label font size now tracks the Zoom control (7pt baseline at 100%, clamped 4-24pt) instead of a fixed size.

- Arrow keys now pan the main structure view, reusing the existing view_apply_pan_delta() mouse-drag-pan code path. Hold Shift for a 4x larger step.

Cairo renderer only; OpenGL structure rendering has no equivalent yet (would need a Cairo-texture overlay pass similar to the existing gradient_overlay mechanism, plus MVP-based world-to-screen projection).