### PR TITLE
Arrow pan fit zoom common pan

### DIFF
--- a/resources/xnec2c.glade
+++ b/resources/xnec2c.glade
@@ -11157,6 +11157,17 @@ Save NEC2 Editor data first?
                         </child>
 
                         <child>
+                          <object class="GtkCheckMenuItem" id="main_common_pan">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Common _Pan</property>
+                            <property name="use-underline">True</property>
+                            <property name="tooltip-text">When enabled, arrow-key panning moves both the structure and radiation pattern windows together instead of only the active window</property>
+                            <signal name="toggled" handler="on_config_widget_changed" swapped="no"/>
+                          </object>
+                        </child>
+
+                        <child>
                           <object class="GtkSeparatorMenuItem">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
@@ -12417,6 +12428,17 @@ Save NEC2 Editor data first?
                             <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Common _Projection</property>
                             <property name="use-underline">True</property>
+                            <signal name="toggled" handler="on_config_widget_changed" swapped="no"/>
+                          </object>
+                        </child>
+
+                        <child>
+                          <object class="GtkCheckMenuItem" id="rdpattern_common_pan">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Common _Pan</property>
+                            <property name="use-underline">True</property>
+                            <property name="tooltip-text">When enabled, arrow-key panning moves both the structure and radiation pattern windows together instead of only the active window</property>
                             <signal name="toggled" handler="on_config_widget_changed" swapped="no"/>
                           </object>
                         </child>

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -785,6 +785,36 @@ opengl_common_projection_sync(void)
     view_unshare_master( rdpattern_view );
 }
 
+/* Common_Pan_Sync()
+ *
+ * Public entry point (mirrors opengl_common_projection_sync() above,
+ * called the same way from main.c on new file load) applying the
+ * persisted common-pan preference. Unlike projection, pan isn't a
+ * live master/follower link -- Pan_View_On_Arrow_Key() already keeps
+ * both views moving together going forward once enabled by mirroring
+ * every arrow-key delta to both. What's still needed is the one-time
+ * "snap to match" the moment the setting turns on (or a new file
+ * loads with it already on), same as toggling Common Projection
+ * immediately re-aligns the rdpattern view rather than waiting for
+ * the next rotation. Only the rdpattern view is moved to match
+ * structure_view; the reverse direction has no natural default since
+ * either view could be "correct" -- structure_view is treated as the
+ * reference the same way it's the master for projection sharing.
+ */
+  void
+Common_Pan_Sync(void)
+{
+  if( !rc_config.common_pan )
+    return;
+
+  if( rdpattern_view == NULL || structure_view == NULL )
+    return;
+
+  rdpattern_view->pan_offset[0] = structure_view->pan_offset[0];
+  rdpattern_view->pan_offset[1] = structure_view->pan_offset[1];
+  view_notify_change( rdpattern_view );
+}
+
 /*-----------------------------------------------------------------------*/
 
 /* view_presets - indexed by preset id: 0=X axis, 1=Y axis, 2=Z axis, 3=default */

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -194,6 +194,57 @@ on_main_window_delete_event(
 }
 
 
+/* Forward declaration: full definition sits near on_fit_view_clicked()
+ * later in this file, shared by that mouse handler and the Home-key
+ * handling in on_main_window_key_press_event()/
+ * on_rdpattern_window_key_press_event() below. */
+static void Fit_View( view_t *target, GCallback zoom_handler );
+
+/* Pan_View_On_Arrow_Key()
+ *
+ * Shared arrow-key panning logic for the structure and radiation pattern
+ * windows. By default each pans ONLY its own view (the window the key
+ * was pressed in) -- users may want to frame each view differently. If
+ * rc_config.common_pan is enabled (View menu: "Common Pan", off by
+ * default, mirroring the existing "Common Projection" toggle), the same
+ * delta is also applied to the OTHER window's view, keeping both in
+ * sync. The two window key-press handlers share this one implementation
+ * rather than duplicating the pan-delta logic. Hold Shift for a 4x
+ * larger step. Returns TRUE if the key was an arrow key and panning was
+ * applied, FALSE otherwise so the caller can fall through to its own
+ * unhandled-key behavior.
+ */
+  static gboolean
+Pan_View_On_Arrow_Key( view_t *v, GdkEventKey *event )
+{
+  const float PAN_STEP_PX      = 15.0f;
+  const float PAN_STEP_PX_FAST = 60.0f;
+  float step = (event->state & GDK_SHIFT_MASK) ? PAN_STEP_PX_FAST : PAN_STEP_PX;
+  float dx = 0.0f, dy = 0.0f;
+
+  switch( event->keyval )
+  {
+    case GDK_KEY_Left:  dx = -step; break;
+    case GDK_KEY_Right: dx =  step; break;
+    case GDK_KEY_Up:    dy = -step; break;
+    case GDK_KEY_Down:  dy =  step; break;
+    default: return( FALSE );
+  }
+
+  if( v != NULL )
+    view_apply_pan_delta( v, dx, dy );
+
+  if( rc_config.common_pan )
+  {
+    view_t *other = (v == structure_view) ? rdpattern_view : structure_view;
+    if( other != NULL )
+      view_apply_pan_delta( other, dx, dy );
+  }
+
+  return( TRUE );
+}
+
+
   gboolean
 on_main_window_key_press_event(
     GtkWidget    *widget,
@@ -221,6 +272,16 @@ on_main_window_key_press_event(
         return( TRUE );
     }
   }
+
+  if( event->keyval == GDK_KEY_Home )
+  {
+    Fit_View( structure_view, G_CALLBACK(on_main_zoom_spinbutton_value_changed) );
+    return( TRUE );
+  }
+
+  if( Pan_View_On_Arrow_Key( structure_view, event ) )
+    return( TRUE );
+
   return( FALSE );
 }
 
@@ -2077,6 +2138,16 @@ on_rdpattern_window_key_press_event(
         return( TRUE );
     }
   }
+
+  if( event->keyval == GDK_KEY_Home )
+  {
+    Fit_View( rdpattern_view, G_CALLBACK(on_rdpattern_zoom_spinbutton_value_changed) );
+    return( TRUE );
+  }
+
+  if( Pan_View_On_Arrow_Key( rdpattern_view, event ) )
+    return( TRUE );
+
   return( FALSE );
 }
 
@@ -5505,6 +5576,35 @@ on_zoom_reset_clicked(
 
 
 /**
+ * Fit_View() - Fit a view's active rendered content, syncing its zoom spinbutton
+ * @target:       the view_t to fit (structure_view or rdpattern_view)
+ * @zoom_handler: that view's zoom spinbutton value-changed callback, blocked
+ *                during the fit so it doesn't re-trigger on the resulting
+ *                zoom change
+ *
+ * Shared by on_fit_view_clicked() (mouse) and the Home-key handlers in
+ * on_main_window_key_press_event()/on_rdpattern_window_key_press_event(),
+ * so both input paths go through one implementation.
+ */
+  static void
+Fit_View( view_t *target, GCallback zoom_handler )
+{
+  view_fit_t fit = {0};
+
+  if( target == NULL || !render_fit_view(target, &fit) )
+    return;
+
+  if( target->zoom_spin != NULL )
+    SIGNAL_BLOCK(target->zoom_spin, zoom_handler);
+
+  view_apply_fit(target, &fit);
+
+  if( target->zoom_spin != NULL )
+    SIGNAL_UNBLOCK(target->zoom_spin, zoom_handler);
+}
+
+
+/**
  * on_fit_view_clicked() - Fit the clicked window's active rendered content
  * @button:     fit-view button identifying the target window
  * @_user_data: unused Glade callback data
@@ -5516,7 +5616,6 @@ on_fit_view_clicked(
 {
   view_t *target = NULL;
   GCallback zoom_handler = NULL;
-  view_fit_t fit = {0};
 
   (void)_user_data;
 
@@ -5531,16 +5630,7 @@ on_fit_view_clicked(
     zoom_handler = G_CALLBACK(on_rdpattern_zoom_spinbutton_value_changed);
   }
 
-  if( target == NULL || !render_fit_view(target, &fit) )
-    return;
-
-  if( target->zoom_spin != NULL )
-    SIGNAL_BLOCK(target->zoom_spin, zoom_handler);
-
-  view_apply_fit(target, &fit);
-
-  if( target->zoom_spin != NULL )
-    SIGNAL_UNBLOCK(target->zoom_spin, zoom_handler);
+  Fit_View( target, zoom_handler );
 }
 
 

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -32,6 +32,7 @@
 
 /* OpenGL common projection sync */
 void opengl_common_projection_sync(void);
+void Common_Pan_Sync(void);
 
 #ifndef HAVE_OPENGL
 /* Hide a widget by builder id; removes OpenGL-only toolbar buttons */

--- a/src/common.h
+++ b/src/common.h
@@ -473,6 +473,7 @@ typedef struct
 
   /* Main window common projection toggle */
   int main_common_projection;
+  int common_pan;
 
   /* Rdpattern overlay structure toggle */
   int rdpattern_overlay_structure;

--- a/src/config_hooks.c
+++ b/src/config_hooks.c
@@ -47,6 +47,14 @@ hook_common_projection(void)
 /*------------------------------------------------------------------------*/
 
 void
+hook_common_pan(void)
+{
+  Common_Pan_Sync();
+}
+
+/*------------------------------------------------------------------------*/
+
+void
 hook_flow_direction(void)
 {
   gboolean animatable;

--- a/src/config_hooks.h
+++ b/src/config_hooks.h
@@ -34,6 +34,7 @@ void config_hooks_init(void);
 
 void hook_polarization(void);
 void hook_common_projection(void);
+void hook_common_pan(void);
 void hook_flow_direction(void);
 void hook_color_vis(void);
 void hook_color_family(void);

--- a/src/main.c
+++ b/src/main.c
@@ -723,6 +723,12 @@ Open_Input_File( gpointer arg )
     }
     /* Preserve existing view when re-opening same file */
 #endif
+
+    /* Snap rdpattern pan to match structure on new file load, same
+     * condition as projection sync above -- renderer-agnostic, so
+     * outside the HAVE_OPENGL guard. */
+    if( !same_file )
+      Common_Pan_Sync();
   }
 
   /* Re-initiate frequency plots if window open */

--- a/src/rc_config.c
+++ b/src/rc_config.c
@@ -273,7 +273,7 @@ rc_config_vars_t rc_config_vars[] = {
 
 	{ .desc = "Common Pan (couple structure/rdpattern arrow-key panning)", .format = "%d",
 		.vars = { &rc_config.common_pan }, .def = { { .i = 0 } },
-		.widgets = CONFIG_WIDGET_TREE( .post_apply = NULL,
+		.widgets = CONFIG_WIDGET_TREE( .post_apply = hook_common_pan,
 			.groups = CONFIG_WIDGET_GROUPS(
 				CONFIG_WIDGET_GROUP( .builder = &main_window_builder,
 					.elements = CONFIG_WIDGETS(

--- a/src/rc_config.c
+++ b/src/rc_config.c
@@ -271,6 +271,18 @@ rc_config_vars_t rc_config_vars[] = {
 						CONFIG_WIDGET( .widget_id = "rdpattern_common_projection" ), NULL ) ),
 				NULL ) ) },
 
+	{ .desc = "Common Pan (couple structure/rdpattern arrow-key panning)", .format = "%d",
+		.vars = { &rc_config.common_pan }, .def = { { .i = 0 } },
+		.widgets = CONFIG_WIDGET_TREE( .post_apply = NULL,
+			.groups = CONFIG_WIDGET_GROUPS(
+				CONFIG_WIDGET_GROUP( .builder = &main_window_builder,
+					.elements = CONFIG_WIDGETS(
+						CONFIG_WIDGET( .widget_id = "main_common_pan" ), NULL ) ),
+				CONFIG_WIDGET_GROUP( .builder = &rdpattern_window_builder,
+					.elements = CONFIG_WIDGETS(
+						CONFIG_WIDGET( .widget_id = "rdpattern_common_pan" ), NULL ) ),
+				NULL ) ) },
+
 	{ .desc = "Radiation Pattern Window Overlay Structure", .format = "%d",
 		.vars = { &rc_config.rdpattern_overlay_structure },
 		.widgets = CONFIG_WIDGET_SINGLE( &rdpattern_window_builder,


### PR DESCRIPTION
Per feedback: arrow-key panning no longer applies to both windows
simultaneously by default -- each window's arrow keys pan only that
window's own view (structure_view or rdpattern_view), via a shared
Pan_View_On_Arrow_Key() helper that takes the target view explicitly.

Adds Home key as a second binding to the existing fit-to-view
functionality (render_fit_view()/view_apply_fit()), alongside the
existing Ctrl+0/KP_0 binding. Shared logic extracted from
on_fit_view_clicked() into a Fit_View() helper.

Also adds a 'Common Pan' checkbox to the View menu of both windows
(off by default), mirroring the existing 'Common Projection' toggle
pattern exactly (one rc_config-backed setting, two synced widget
instances via CONFIG_WIDGET_TREE). When enabled, arrow-key panning
in either window also pans the other window's view by the same
delta, restoring the coupled behavior as an opt-in rather than a
default.

Adds Common_Pan_Sync(), mirroring opengl_common_projection_sync()'s
structure and call sites: wired as the .post_apply hook for the
Common Pan setting (previously NULL), so toggling it on immediately
snaps rdpattern_view's pan_offset to match structure_view's -- the
same 'reset' moment Common Projection already gives on toggle. Also
projection sync uses), so opening a file with Common Pan already
enabled starts both views aligned.

Note: unlike projection's live master/follower link
(view_share_master()), pan has no equivalent primitive in view_t, so
this is a one-time snap on toggle/load; ongoing sync during arrow-key
panning is handled separately by Pan_View_On_Arrow_Key() mirroring
each delta to both views (added in the prior commit on this branch).